### PR TITLE
fix: Windows Task Scheduler repetition trigger fails silently

### DIFF
--- a/mobile-app/lib/core/services/powershell_script_generator.dart
+++ b/mobile-app/lib/core/services/powershell_script_generator.dart
@@ -198,27 +198,23 @@ try {
 
   /// Generate trigger configuration for given frequency
   ///
-  /// [FIX] ISSUE #161: Changed from -Once -At (Get-Date) to -Daily trigger
-  /// with repetition. The -Once trigger with a past start time does not
-  /// persist across reboots reliably on Windows. Using -Daily -At midnight
-  /// with RepetitionInterval ensures the task runs consistently even after
-  /// system restarts.
+  /// Uses -Once trigger with -RepetitionInterval and -RepetitionDuration
+  /// parameters for sub-daily frequencies. The repetition parameters must
+  /// be passed directly to New-ScheduledTaskTrigger (not set as properties
+  /// after creation, as the Repetition sub-object is null on new triggers).
+  ///
+  /// [FIX] ISSUE #161: -Once with past start time does not persist across
+  /// reboots. Using -At "12:00AM" with repetition ensures consistent runs.
   static String _getTriggerForFrequency(ScanFrequency frequency) {
     switch (frequency) {
       case ScanFrequency.every15min:
-        return r'''$trigger = New-ScheduledTaskTrigger -Daily -At "12:00AM"
-$trigger.Repetition.Interval = (New-TimeSpan -Minutes 15).ToString()
-$trigger.Repetition.Duration = (New-TimeSpan -Days 365).ToString()''';
+        return r'$trigger = New-ScheduledTaskTrigger -Once -At "12:00AM" -RepetitionInterval (New-TimeSpan -Minutes 15) -RepetitionDuration (New-TimeSpan -Days 365)';
 
       case ScanFrequency.every30min:
-        return r'''$trigger = New-ScheduledTaskTrigger -Daily -At "12:00AM"
-$trigger.Repetition.Interval = (New-TimeSpan -Minutes 30).ToString()
-$trigger.Repetition.Duration = (New-TimeSpan -Days 365).ToString()''';
+        return r'$trigger = New-ScheduledTaskTrigger -Once -At "12:00AM" -RepetitionInterval (New-TimeSpan -Minutes 30) -RepetitionDuration (New-TimeSpan -Days 365)';
 
       case ScanFrequency.every1hour:
-        return r'''$trigger = New-ScheduledTaskTrigger -Daily -At "12:00AM"
-$trigger.Repetition.Interval = (New-TimeSpan -Hours 1).ToString()
-$trigger.Repetition.Duration = (New-TimeSpan -Days 365).ToString()''';
+        return r'$trigger = New-ScheduledTaskTrigger -Once -At "12:00AM" -RepetitionInterval (New-TimeSpan -Hours 1) -RepetitionDuration (New-TimeSpan -Days 365)';
 
       case ScanFrequency.daily:
         return r'$trigger = New-ScheduledTaskTrigger -Daily -At "09:00AM"';

--- a/mobile-app/test/unit/services/powershell_script_generator_test.dart
+++ b/mobile-app/test/unit/services/powershell_script_generator_test.dart
@@ -34,7 +34,7 @@ void main() {
         expect(content, contains(taskName));
         expect(content, contains(executablePath));
         expect(content, contains('--background-scan'));
-        expect(content, contains('Repetition.Interval'));
+        expect(content, contains('RepetitionInterval'));
         expect(content, contains('Minutes 15'));
       });
 


### PR DESCRIPTION
## Summary

- **fix**: Windows Task Scheduler background scan triggers fail silently. Task creates with exit code 0 but repetition (every 15min/30min/1hr) does not work, running only once daily instead.

Fixes #176

## Root Cause

The `-Daily` trigger in `New-ScheduledTaskTrigger` creates a trigger where `$trigger.Repetition` is null. Property assignments fail silently (stderr only, exit 0).

## Fix

Use `-Once` with inline `-RepetitionInterval` and `-RepetitionDuration` parameters instead of setting properties after trigger creation.

## Test plan

- [x] All 12 `powershell_script_generator_test.dart` tests pass
- [x] All 9 `windows_task_scheduler_service_test.dart` tests pass
- [x] Full test suite: 1087 passed, 28 skipped, 0 failures
- [x] User verified: background scan job running correctly in production

Generated with [Claude Code](https://claude.com/claude-code)