### PR TITLE
Sprint 28: MSIX Sandbox Fix + UX Improvements (B1, F49, F51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 
 ## [Unreleased]
 
+### 2026-04-02 (Sprint 28 - MSIX Sandbox Fix + UX Improvements)
+- **fix**: Replace all hardcoded Platform.environment['APPDATA'] paths with path_provider for MSIX sandbox compatibility (B1, Issue #218)
+- **fix**: Add MSIX detection (AppEnvironment.isMsixInstall) and skip Task Scheduler in MSIX context (B1, Issue #218)
+- **fix**: app_identity_migration.dart uses path_provider instead of raw APPDATA (Issue #218)
+- **fix**: dev_environment_seeder.dart uses path_provider instead of raw APPDATA (Issue #218)
+- **fix**: background_scan_windows_worker.dart uses cached path_provider log directory (Issue #218)
+- **feat**: Remove "Scan All N Accounts" button from account selection screen (F49, Issue #219)
+- **feat**: View Scan History on account selection shows account selection dialog (F49, Issue #219)
+- **feat**: Scan History title shows account email when filtered by account (F49, Issue #219)
+- **feat**: Background settings: Scan Mode moved above Default Folders to match Manual Scan layout (F51, Issue #221)
+
 ### 2026-03-30 (Sprint 27 - Desktop App E2E Testing with civyk-winwright)
 - **feat**: Install civyk-winwright MCP server for automated Windows Desktop UI testing (F11)
 - **feat**: Discover Flutter Desktop requires SPI_SETSCREENREADER flag for accessibility tree activation (F11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 - **feat**: View Scan History on account selection shows account selection dialog (F49, Issue #219)
 - **feat**: Scan History title shows account email when filtered by account (F49, Issue #219)
 - **feat**: Background settings: Scan Mode moved above Default Folders to match Manual Scan layout (F51, Issue #221)
+- **fix**: Account selection dialog displays correct email and platform from cached data (Issue #219)
+- **fix**: Test Background Scan runs all accounts regardless of Enable Background Scanning toggle
+- **chore**: Add local MSIX testing support (create-test-cert.ps1, store/test toggle docs)
 
 ### 2026-03-30 (Sprint 27 - Desktop App E2E Testing with civyk-winwright)
 - **feat**: Install civyk-winwright MCP server for automated Windows Desktop UI testing (F11)

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -4,7 +4,7 @@
 
 **Audience**: Claude Code models planning sprints; User prioritizing future work
 
-**Last Updated**: April 2, 2026 (Sprint 27 retrospective)
+**Last Updated**: April 2, 2026 (Sprint 28 retrospective)
 
 ## How to Maintain This Document
 
@@ -92,6 +92,7 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 | 25 | docs/sprints/SPRINT_25_RETROSPECTIVE.md | [OK] Complete | Mar 22, 2026 |
 | 26 | docs/sprints/SPRINT_26_RETROSPECTIVE.md | [OK] Complete | Mar 22-24, 2026 |
 | 27 | docs/sprints/SPRINT_27_RETROSPECTIVE.md | [OK] Complete | Mar 29 - Apr 2, 2026 |
+| 28 | docs/sprints/SPRINT_28_RETROSPECTIVE.md | [OK] Complete | Apr 2, 2026 |
 
 **Key Achievements**: See CHANGELOG.md for detailed feature history.
 
@@ -99,31 +100,26 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 
 ## Last Completed Sprint
 
-**Sprint 27** (March 29 - April 2, 2026)
-- **Features**: F11 Desktop App E2E Testing with civyk-winwright
-- **Key Findings**: Flutter requires SPI_SETSCREENREADER flag for accessibility tree; all 11 screens automatable; tabs need useInvokePattern:false
-- **Tools**: civyk-winwright v2.0.0, enable-screen-reader-flag.ps1, ww-test-helper.sh
-- **Bug Fix**: Flutter SDK sqlite3 native assets PathExistsException (build-windows.ps1 workaround)
-- **Process**: Mandatory metadata update enforcement in /startup-check, /memory-restore skills
-- **Retrospective**: docs/sprints/SPRINT_27_RETROSPECTIVE.md
+**Sprint 28** (April 2, 2026)
+- **Bug Fix**: B1 MSIX sandbox crash at launch - replaced hardcoded APPDATA paths with path_provider (Issue #218)
+- **Features**: F49 Remove Scan All Accounts + account-specific Scan History (Issue #219), F51 Background settings reorder (Issue #221)
+- **Bug Fixes**: Account selection dialog display, Test Background Scan runs all accounts
+- **MSIX**: Built, installed, launched successfully in local testing
+- **Process**: Sprint summary made mandatory in Phase 7, winwright E2E added to Phase 5, python3 hook fix
+- **Retrospective**: docs/sprints/SPRINT_28_RETROSPECTIVE.md
 
 ---
 
 ## Next Sprint Candidates
 
-**Last Reviewed**: April 2, 2026 (Sprint 27 retrospective)
+**Last Reviewed**: April 2, 2026 (Sprint 28 retrospective)
 
 All incomplete items in relative priority order. Priority in increments of 10; items that can sprint together in increments of 2. HOLD items grouped at bottom. See [Feature and Bug Details](#feature-and-bug-details) for deep-dive specs. See [BACKLOG_REFINEMENT.md](BACKLOG_REFINEMENT.md) for presentation format rules.
 
 ### Windows Store Readiness
 
-**B1. MSIX sandbox crash at launch - File system error (Issue #218) (~10h) Priority 1**
-- Phase: Windows Store Readiness (BLOCKER)
-- Platform: Windows Desktop
-- Target: Sprint 28
-- Microsoft Store certification fails: app crashes at launch inside MSIX sandbox
-- Error: `File system error (-2015295536)` / 0x87E107D0
-- [Detail](#b1-msix-sandbox-crash-at-launch)
+**~~B1. MSIX sandbox crash at launch - File system error (Issue #218) (~10h)~~** [OK] Complete (Sprint 28)
+- Awaiting Microsoft Store resubmission and certification verification
 
 **~~WS-B1. MSIX config fixes (~1h)~~** [OK] Complete (Sprint 23)
 
@@ -183,20 +179,14 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 
 **~~F7. Multi-Account Scanning~~** [OK] Complete (Sprint 26)
 
-**F49. Remove "Scan All Accounts" button, add account selection to Scan History (Issue #219) (~2-3h) Priority 80**
-- Phase: UX Improvement
-- Platform: All
-- Sprint 27 retrospective feedback: multi-account simultaneous scanning not needed
+**~~F49. Remove "Scan All Accounts" button, add account selection to Scan History (Issue #219) (~2-3h)~~** [OK] Complete (Sprint 28)
 
 **F50. Make all page text selectable and copyable to clipboard (Issue #220) (~4-6h) Priority 82**
 - Phase: UX Improvement
 - Platform: All
 - Sprint 27 retrospective feedback: extend existing selectable text pattern to all screens
 
-**F51. Background settings - move Scan Mode above Default Folders (Issue #221) (~0.5h) Priority 84**
-- Phase: UX Improvement
-- Platform: All
-- Sprint 27 retrospective feedback: match Manual Scan settings page layout order
+**~~F51. Background settings - move Scan Mode above Default Folders (Issue #221) (~0.5h)~~** [OK] Complete (Sprint 28)
 
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance

--- a/docs/SPRINT_CHECKLIST.md
+++ b/docs/SPRINT_CHECKLIST.md
@@ -110,6 +110,20 @@ These documents MUST be created/updated during each sprint:
 - [ ] **Review and close all resolved GitHub issues** (`gh issue list --state open` - close any resolved by this sprint)
 - [ ] GitHub issues auto-closed (verify Closes #N references worked)
 - [ ] Feature branch deleted (optional, user-managed)
+
+## Post-Merge: Store Submission (if applicable)
+
+If the sprint included changes that affect the Microsoft Store build (UI changes, bug fixes, MSIX fixes):
+
+- [ ] Merge develop to main (user)
+- [ ] Build Store MSIX: set `store: true` in pubspec.yaml, run `dart run msix:create`
+- [ ] Upload MSIX to Microsoft Partner Center
+- [ ] Submit for certification
+- [ ] **Notify user** when build is ready for upload or when submission is complete
+
+## Ready for Next Sprint
+
+- [ ] All post-merge steps complete
 - [ ] Ready for next sprint
 
 ---

--- a/docs/SPRINT_CHECKLIST.md
+++ b/docs/SPRINT_CHECKLIST.md
@@ -37,7 +37,7 @@ These documents MUST be created/updated during each sprint:
 - [ ] Sprint number determined (N = previous + 1)
 - [ ] Read ALL_SPRINTS_MASTER_PLAN.md "Next Sprint Candidates" table
 - [ ] **Present candidates in sprint refinement format** (BACKLOG_REFINEMENT.md format, not grid tables)
-- [ ] Created `docs/sprints/SPRINT_(N-1)_SUMMARY.md` for previous sprint (3.2.1)
+- [ ] **Verify** `docs/sprints/SPRINT_(N-1)_SUMMARY.md` exists for previous sprint (created in Phase 7)
 - [ ] **Created `docs/sprints/SPRINT_N_PLAN.md`** for current sprint (3.2.2 - MANDATORY)
 - [ ] Created feature branch: `feature/YYYYMMDD_Sprint_N`
 - [ ] Created GitHub issues for all tasks
@@ -65,6 +65,7 @@ These documents MUST be created/updated during each sprint:
 - [ ] Full test suite passing (`flutter test`)
 - [ ] Code analysis clean (`flutter analyze` - target <50 warnings)
 - [ ] Risk mitigations validated
+- [ ] **Desktop E2E tests** (if UI changes): Run winwright accessibility tests on affected screens (see `docs/WINWRIGHT_SELECTORS.md`)
 - [ ] **App built for user testing** (Windows: `build-windows.ps1`)
 - [ ] **Platform-specific UI verified** at native level (Win32 window title, system tray, notifications) -- Flutter UI layer may not control platform-level behavior (learned Sprint 21)
 - [ ] Manual testing complete (user)
@@ -97,7 +98,7 @@ These documents MUST be created/updated during each sprint:
   - [ ] CHANGELOG.md updated (all sprint entries present)
   - [ ] ALL_SPRINTS_MASTER_PLAN.md updated (per Maintenance Guide rules)
   - [ ] `docs/sprints/SPRINT_N_RETROSPECTIVE.md` created (MANDATORY)
-  - [ ] `docs/sprints/SPRINT_N_SUMMARY.md` created (or deferred to next sprint Phase 3.2.1)
+  - [ ] `docs/sprints/SPRINT_N_SUMMARY.md` created (MANDATORY - do not defer)
   - [ ] ARCHITECTURE.md updated (if architecture changed)
   - [ ] .claude/sprint_status.json updated
 - [ ] Review results summarized

--- a/docs/sprints/SPRINT_13_SUMMARY.md
+++ b/docs/sprints/SPRINT_13_SUMMARY.md
@@ -1,0 +1,28 @@
+# Sprint 13 Summary
+
+**Sprint**: Sprint 13 - Account Settings, Scan Results Enhancements and Testing Feedback Fixes
+**Date**: February 6, 2026
+**Status**: [OK] Complete
+**PR**: #136
+
+## What Was Done
+Implemented per-account folder configuration for safe senders and deleted rules, simplified the Settings UI by removing the Account tab, and enhanced subject line display quality by cleaning non-keyboard characters.
+
+## Key Deliverables
+- F16A: Clean subject lines in Scan Results and CSV export (remove emoji, repeated punctuation, non-ASCII)
+- F15: Removed Account tab from Settings screen, simplified to 2 tabs (Manual Scan, Background)
+- F14: Per-account "Move Deleted by Rule to Folder" setting with UI in Account Maintenance
+- F13: Per-account "Move Safe Senders to Folder" setting with conditional move logic (skip if already in target folder)
+- 17 new unit tests for subject cleaning
+- 932 tests passing, analyzer clean
+
+## Retrospective Highlights
+- Original estimate 26-33 hours, actual approximately 3 hours (9x faster due to user simplifying scope)
+- 10 critical process improvements identified in retrospective analysis, including sprint execution autonomy enforcement and emoji-free documentation policy
+- Sprint scope was completely replanned from original F5/F12 features to F13/F14/F15/F16A based on user priorities
+
+## Files Created/Modified
+- Core: settings_store.dart, email_scanner.dart, spam_filter_platform.dart, all 3 adapters
+- UI: settings_screen.dart, account_maintenance_screen.dart
+- Tests: pattern_normalization_test.dart (17 new tests)
+- 14 files total

--- a/docs/sprints/SPRINT_16_SUMMARY.md
+++ b/docs/sprints/SPRINT_16_SUMMARY.md
@@ -1,0 +1,24 @@
+# Sprint 16 Summary
+
+**Sprint**: Sprint 16 - UX Polish, Scan Configuration, and Rule Intelligence
+**Date**: February 15-16, 2026
+**Status**: [OK] Complete
+**PR**: #155
+
+## What Was Done
+Added persistent days-back scan configuration for both manual and background scans, simplified scan UI, added a background scan log viewer with history and stats, and implemented rule override detection to warn users of conflicts.
+
+## Key Deliverables
+- Issue #153: Persistent days-back settings for Manual and Background scans with slider UI
+- Issue #150: Scan Options dialog defaults to "Scan all emails" with persistent setting
+- Issue #151: Renamed "Scan Progress" to "Manual Scan", removed redundant folder selector
+- Issue #152: Background scan log viewer with history, stats, per-scan drill-down, and CSV export
+- Issue #139: Rule override/conflict detection with warning UI (16 unit tests)
+- Scan result persistence in database (email_actions table)
+- 8 rounds of user testing feedback incorporated (FB-1 through FB-8)
+
+## Metrics
+- 977 tests passing, 28 skipped
+- 48 files changed, +5,848 / -494 lines
+- 15 commits
+- 5 new issues created from testing feedback (#156-#160)

--- a/docs/sprints/SPRINT_24_SUMMARY.md
+++ b/docs/sprints/SPRINT_24_SUMMARY.md
@@ -1,0 +1,25 @@
+# Sprint 24 Summary
+
+**Sprint**: Sprint 24 - Windows Store Readiness: Privacy Policy, Store Assets, and Submission
+**Date**: March 20-21, 2026
+**Status**: [OK] Complete
+**PR**: #199
+
+## What Was Done
+Completed all Windows Store readiness items: published a privacy policy website, created store listing assets, and submitted the app to the Microsoft Store for certification.
+
+## Key Deliverables
+- Privacy policy website created at docs/website/ for myemailspamfilter.com (landing, privacy, data deletion pages)
+- Store listing assets: short description (89 chars), long description (1,914 chars), 5 screenshots, store logos
+- Microsoft Store developer account registered (Kimmey Consulting - Ohio)
+- App name "MyEmailSpamFilter" reserved (Store ID: 9N5QK9G904C0)
+- MSIX package v0.5.1.0 built and submitted for certification
+- Executable renamed: spam_filter_mobile to MyEmailSpamFilter
+- Dart package renamed: spam_filter_mobile to my_email_spam_filter (224 imports across 73 files)
+- msix v3.16.8 added as dev dependency
+
+## Metrics
+- 1145 tests passing, 28 skipped, 0 failures
+- Approximately 80+ files changed (primarily from package rename)
+- Duration: approximately 6 hours across 2 sessions
+- 1 bug found during testing: Issue #198 (safe sender matches in Gmail IMAP results)

--- a/docs/sprints/SPRINT_25_SUMMARY.md
+++ b/docs/sprints/SPRINT_25_SUMMARY.md
@@ -1,0 +1,26 @@
+# Sprint 25 Summary
+
+**Sprint**: Sprint 25 - Safe Sender Bug Fixes + Quality Improvements
+**Date**: March 22, 2026
+**Status**: [OK] Complete
+**PR**: #204
+
+## What Was Done
+Fixed safe sender scanning bugs found during Sprint 24 testing, renamed scan mode enums for clarity, added a live scan status indicator, implemented re-process capability after inline rule changes, and established a test coverage baseline.
+
+## Key Deliverables
+- Task A: ScanMode enum values renamed for clarity (readonly to readOnly, testLimit to rulesOnly, etc.) with backwards compatibility
+- Task B (F40): Fixed safe sender INBOX skip bug for Gmail IMAP (Issue #198)
+- Task C (F41): Added safe sender move diagnostic logging for AOL Bulk Mail (Issue #201)
+- Task D (F30): Fixed exact domain filter chip misclassification
+- Task E (F31): Post-build Task Scheduler re-registration in build-windows.ps1
+- Task F (F34): Live scan status indicator with progress bar, completion, and error states
+- Task G (F38): Re-process emails via IMAP after inline rule changes (async non-blocking banner)
+- Task H (F32): Test coverage analysis (28.9% baseline) + 17 RuleSetProvider tests
+- ADR-0035: Prod worktree setup for side-by-side dev/prod execution
+
+## Metrics
+- 31 new tests added (1147 to 1178 passing), 28 skipped
+- Approximately 20 files changed across 16 commits
+- Coverage baseline: 28.9% overall (3476/12037 lines)
+- 5 new backlog items created (F43-F47, Issues #205-#209)

--- a/docs/sprints/SPRINT_26_SUMMARY.md
+++ b/docs/sprints/SPRINT_26_SUMMARY.md
@@ -1,0 +1,26 @@
+# Sprint 26 Summary
+
+**Sprint**: Sprint 26 - Settings UX, Excel Export, Provider Warnings, Multi-Account
+**Date**: March 22-24, 2026
+**Status**: [OK] Complete
+**PR**: #213
+
+## What Was Done
+Improved settings UX with folder selection auto-save and a new General tab, converted background scan output to Excel format, added email provider domain warnings on rule creation, and implemented multi-account sequential scanning.
+
+## Key Deliverables
+- F43: Folder settings radio button auto-save UX with current folder display
+- F44: "Go to View Scan History" link on Manual Scan settings and Account tab
+- F45: Background scan Excel export (.xlsx) with daily file grouping and env-aware filenames (syncfusion_flutter_xlsio)
+- F47: Email provider domain warning popup for domain-level Safe Sender/Block Rules
+- F36: Settings General tab - moved Rules Management, Scan History, About from Account tab
+- F7: Multi-Account Scanning - "Scan All Accounts" button for sequential scanning
+- View Scan History icon added to Results, Account Selection, and all Settings AppBars
+- 3 bugs fixed during testing: Excel file location, ScanMode firstWhere crash, SettingsStore wrong DB path
+
+## Metrics
+- 1178 tests passing, 28 skipped, 0 failures
+- Approximately 10 files changed across 13 commits
+- Duration: 2 sessions (March 22-24)
+- Issues closed: #205, #206, #207, #209, #211
+- 1 new issue created: #212 (F48 scan history enhancements)

--- a/docs/sprints/SPRINT_28_PLAN.md
+++ b/docs/sprints/SPRINT_28_PLAN.md
@@ -1,0 +1,228 @@
+# Sprint 28 Plan
+
+**Sprint**: Sprint 28 - MSIX Sandbox Fix + UX Improvements
+**Date**: April 2, 2026
+**Branch**: `feature/20260402_Sprint_28`
+**Base**: `develop`
+**Estimated Total Effort**: ~12-14h
+
+---
+
+## Sprint Goal
+
+Fix the Microsoft Store certification blocker (MSIX sandbox crash at launch) and implement UX improvements from Sprint 27 retrospective feedback.
+
+---
+
+## Background
+
+Microsoft Store certification failed with `File system error (-2015295536)` at app launch. Root cause: `sqfliteFfiInit()` fails inside the MSIX sandbox due to DLL loading/path restrictions. Additionally, hardcoded `%APPDATA%` paths and `Platform.resolvedExecutable` usage cause issues in the virtualized MSIX environment.
+
+UX improvements from Sprint 27 retrospective: remove unnecessary "Scan All Accounts" button, add account selection to Scan History navigation, and reorder Background settings sections.
+
+**Backlog items**: B1 (Issue #218), F49 (Issue #219), F51 (Issue #221)
+
+---
+
+## Tasks
+
+### Task 1: Fix sqflite FFI initialization for MSIX sandbox (~4h)
+
+**Model**: Sonnet
+**Execution**: Autonomous
+**Issue**: #218 (Task 1)
+
+Evaluate and implement the best approach for sqlite3 to work inside the MSIX sandbox.
+
+**Current state**:
+- `main.dart:36` calls `sqfliteFfiInit()` with no parameters
+- `main.dart:37` sets `databaseFactory = databaseFactoryFfi`
+- Import: `package:sqflite_common_ffi/sqflite_ffi.dart` (line 7)
+- `sqlite3` v3.1.4 is already a transitive dependency with build hooks that bundle the DLL
+
+**Options to evaluate**:
+- **Option A** (Preferred): Add `sqlite3_flutter_libs` dependency to bundle sqlite3 as a proper Flutter plugin native asset. Keep sqflite API. Least code change.
+- **Option B**: Configure `sqfliteFfiInit()` with explicit DLL path pointing to bundled sqlite3.dll
+- **Option C**: Replace `sqflite_common_ffi` entirely with `sqlite3` v3.x direct API or `drift`
+
+**Evaluation criteria**: Least code change, best MSIX compatibility, no API migration risk.
+
+**Acceptance Criteria**:
+- [ ] sqlite3 DLL loads correctly inside MSIX sandbox
+- [ ] Database opens and reads/writes correctly
+- [ ] No `.dart_tool/` directory created in read-only install directory
+- [ ] Existing sqflite API calls continue to work (no migration needed)
+- [ ] `flutter build windows` succeeds
+- [ ] `dart run msix:create` succeeds
+
+### Task 2: Replace hardcoded APPDATA paths with path_provider (~2h)
+
+**Model**: Sonnet
+**Execution**: Autonomous
+**Issue**: #218 (Task 2)
+
+Replace all `Platform.environment['APPDATA']` usage with `AppPaths` methods that use `path_provider`.
+
+**Files to modify** (6 occurrences):
+
+| File | Line | Current Usage | Fix |
+|------|------|---------------|-----|
+| `lib/main.dart` | 49 | Background scan log path | Use `AppPaths.logsDirectory` |
+| `lib/core/services/background_scan_windows_worker.dart` | 30 | Background scan log path | Use `AppPaths.logsDirectory` |
+| `lib/core/services/background_scan_windows_worker.dart` | 279 | Excel export directory | Use `AppPaths.logsDirectory` |
+| `lib/core/services/app_identity_migration.dart` | 29 | Old app data path | Use `path_provider` `getApplicationSupportDirectory()` |
+| `lib/core/services/app_identity_migration.dart` | 35 | New app data path | Use `path_provider` `getApplicationSupportDirectory()` |
+| `lib/core/services/dev_environment_seeder.dart` | 28 | App data path | Use `path_provider` `getApplicationSupportDirectory()` |
+
+**Note**: `AppPaths` already has `logsDirectory` (line 167) and `appSupportDirectory` (line 90). The background scan log and worker paths need `AppPaths` to be initialized before use. `main.dart:49` runs before `AppPaths.initialize()`, so we may need to initialize AppPaths earlier or defer the log file creation.
+
+**Acceptance Criteria**:
+- [ ] Zero occurrences of `Platform.environment['APPDATA']` in `lib/` directory
+- [ ] Background scan log writes to correct path in MSIX and non-MSIX
+- [ ] Excel export writes to correct path
+- [ ] Legacy app identity migration still works for non-MSIX installs
+- [ ] Dev environment seeder still works
+
+### Task 3: Handle Platform.resolvedExecutable in MSIX context (~1h)
+
+**Model**: Sonnet
+**Execution**: Autonomous
+**Issue**: #218 (Task 3)
+
+Add MSIX detection and adapt Task Scheduler behavior.
+
+**Current state**:
+- `windows_task_scheduler_service.dart:259,369` uses `Platform.resolvedExecutable`
+- Inside MSIX, this path is under `C:\Program Files\WindowsApps\...` (read-only, changes on updates)
+- Task Scheduler registration will fail or point to stale paths after updates
+
+**Fix approach**:
+- Add MSIX detection: check if `Platform.resolvedExecutable` contains `WindowsApps`
+- If MSIX: skip Task Scheduler registration (MSIX apps should use StartupTask or BackgroundTask APIs)
+- Log MSIX detection at startup for diagnostics
+- Background scanning in MSIX builds will need a different mechanism (future sprint)
+
+**Acceptance Criteria**:
+- [ ] MSIX detected correctly when running from WindowsApps directory
+- [ ] Task Scheduler registration skipped in MSIX context (no crash)
+- [ ] Non-MSIX builds continue to use Task Scheduler normally
+- [ ] Diagnostic log message indicates MSIX vs non-MSIX mode
+
+### Task 4: Build and test MSIX package locally (~2h)
+
+**Model**: Sonnet
+**Execution**: Autonomous (with user verification)
+**Issue**: #218 (Task 4)
+
+Build MSIX package and verify it works.
+
+**Steps**:
+1. Run `flutter build windows --release`
+2. Run `dart run msix:create` to build MSIX
+3. Install MSIX on local machine
+4. Launch app from Start Menu
+5. Verify: app launches, database loads, rules load
+6. Verify: manual scan starts (read-only mode)
+7. Verify: settings screens work
+8. Document any remaining issues
+
+**Acceptance Criteria**:
+- [ ] MSIX builds successfully
+- [ ] App installs from MSIX package
+- [ ] App launches without "File system error"
+- [ ] Database creates and loads rules
+- [ ] Manual scan in read-only mode works
+- [ ] Settings screens accessible
+
+### Task 5: Remove "Scan All Accounts" button (~0.5h)
+
+**Model**: Haiku
+**Execution**: Autonomous
+**Issue**: #219
+
+Remove the "Scan All N Accounts" button from the account selection screen.
+
+**File**: `lib/ui/screens/account_selection_screen.dart`
+- Remove button at lines 732-742
+- Remove `_scanAllAccounts()` method at lines 396-487
+- Clean up any related state/variables
+
+**Acceptance Criteria**:
+- [ ] "Scan All N Accounts" button no longer appears
+- [ ] Individual account "Start Scan" buttons still work
+- [ ] No dead code remaining from removed feature
+
+### Task 6: Add account selection dialog to View Scan History + show account in history (~2h)
+
+**Model**: Haiku
+**Execution**: Autonomous
+**Issue**: #219
+
+Two changes:
+1. On the Account Selection screen, the "View Scan History" AppBar button should show the same account selection dialog as the "Settings" button (pattern at `_openSettings()` lines 511-559), then navigate to `ScanHistoryScreen` with the selected `accountId` and `accountEmail`.
+
+2. Update `ScanHistoryScreen` to show the account email in the title when filtered by account.
+
+**Files**:
+- `lib/ui/screens/account_selection_screen.dart` — modify `_buildHistoryButton()` (lines 571-584) to show dialog
+- `lib/ui/screens/scan_history_screen.dart` — update title from static "Scan History" (line 100) to `"Scan History - ${widget.accountEmail}"` when account is provided
+
+**Current patterns**:
+- `ScanHistoryScreen` constructor already accepts `accountId`, `accountEmail`, `platformId`, `platformDisplayName`
+- `_openSettings()` already shows the account selection dialog pattern to reuse
+- `ResultsDisplayScreen` already shows account in title: `"Results - ${widget.accountEmail} - ${widget.platformDisplayName}"` (line 483)
+
+**Acceptance Criteria**:
+- [ ] View Scan History on account selection screen shows account selection dialog
+- [ ] After selecting account, navigates to Scan History filtered for that account
+- [ ] Scan History title shows account email when filtered (e.g., "Scan History - kimmeyharold@aol.com")
+- [ ] Cancel in dialog returns to account selection (no navigation)
+- [ ] Other View Scan History buttons (from Settings, Results) continue to work
+
+### Task 7: Reorder Background settings - Scan Mode above Default Folders (~0.5h)
+
+**Model**: Haiku
+**Execution**: Autonomous
+**Issue**: #221
+
+In `_buildBackgroundScanTab()` (settings_screen.dart lines 633-711), move the Scan Mode section (lines 689-697) above the Default Folders section (lines 679-687) to match the Manual Scan tab order.
+
+**Desired order** (matching Manual Scan tab):
+1. Enable Background Scanning (checkbox)
+2. Test (test button, scan history link)
+3. Frequency (dropdown)
+4. **Scan Mode** (moved up from position 6)
+5. Scan Range (slider)
+6. Default Folders (folder chips)
+7. Debug (CSV export checkbox)
+
+**Acceptance Criteria**:
+- [ ] Scan Mode section appears before Default Folders on Background tab
+- [ ] Section order matches Manual Scan tab (Mode, Range, Folders)
+- [ ] All settings still save and load correctly
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| sqlite3_flutter_libs may not fully resolve MSIX DLL loading | Test Option B (explicit path) as fallback |
+| MSIX testing requires local install which may conflict with dev build | Use separate test account or VM |
+| Background scanning disabled in MSIX may frustrate Store users | Document as known limitation; implement MSIX-native background in future sprint |
+| Removing Scan All Accounts may break multi-account scan results references | Search for any code that depends on multi-account scan flow |
+
+---
+
+## Test Plan
+
+- [ ] `flutter test` — all existing tests pass
+- [ ] `flutter analyze` — 0 issues
+- [ ] `flutter build windows` — succeeds
+- [ ] `dart run msix:create` — MSIX builds
+- [ ] MSIX install and launch — no crash
+- [ ] Manual scan in read-only mode — works from MSIX
+- [ ] Account selection screen — no "Scan All" button, Scan History shows dialog
+- [ ] Scan History — shows account email in title
+- [ ] Background settings — Scan Mode above Default Folders
+- [ ] Windows build (non-MSIX) — all features still work

--- a/docs/sprints/SPRINT_28_RETROSPECTIVE.md
+++ b/docs/sprints/SPRINT_28_RETROSPECTIVE.md
@@ -1,0 +1,96 @@
+# Sprint 28 Retrospective
+
+**Sprint**: Sprint 28 - MSIX Sandbox Fix + UX Improvements
+**Date**: April 2, 2026
+**Branch**: `feature/20260402_Sprint_28`
+**PR**: #223
+
+---
+
+## Sprint Goal
+
+Fix the Microsoft Store certification blocker (MSIX sandbox crash at launch) and implement UX improvements from Sprint 27 retrospective feedback.
+
+## Outcome: [OK] Complete
+
+All 7 planned tasks completed, plus 2 bug fixes found during testing.
+
+---
+
+## Tasks Completed
+
+| Task | Description | Status |
+|------|-------------|--------|
+| 1 | Fix sqflite FFI for MSIX | [OK] No changes needed (already correct) |
+| 2 | Replace hardcoded APPDATA paths | [OK] 6 occurrences in 4 files |
+| 3 | MSIX detection + Task Scheduler guard | [OK] AppEnvironment.isMsixInstall |
+| 4 | Build and test MSIX locally | [OK] Installed and launched |
+| 5 | Remove Scan All Accounts button | [OK] |
+| 6 | Account selection dialog for Scan History | [OK] |
+| 7 | Background settings reorder | [OK] |
+
+### Bug Fixes During Testing
+- Account selection dialog showed incorrect email (accountId parsing was wrong)
+- Test Background Scan failed when Enable Background Scanning was off (should always scan)
+
+---
+
+## Retrospective Feedback
+
+### User Feedback (All "Very Good")
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| Effective while Efficient | Very Good | Hook errors (python3, UserPromptSubmit) need fix |
+| Sprint Execution | Very Good | |
+| Testing Approach | Very Good | Winwright tests should be in sprint execution docs |
+| Effort Accuracy | Very Good | |
+| Planning Quality | Very Good | |
+| Model Assignments | Very Good | |
+| Communication | Very Good | |
+| Requirements Clarity | Very Good | |
+| Documentation | Needs Improvement | Missing sprint summaries for 6 sprints |
+| Process Issues | Very Good | |
+| Risk Management | Very Good | |
+| Next Sprint Readiness | Very Good | |
+
+### Claude Feedback
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| Effective while Efficient | Very Good | Research saved effort (sqlite3 already correct) |
+| Sprint Execution | Very Good | All tasks + 2 bug fixes |
+| Testing Approach | Good | MSIX testing was rocky (cert/launch issues) |
+| Effort Accuracy | Very Good | ~12h estimated, close to actual |
+| Planning Quality | Very Good | B1 root cause analysis was accurate |
+| Model Assignments | Good | Sonnet tasks handled by Haiku successfully |
+| Communication | Good | Should have verified accountId format first |
+| Requirements Clarity | Very Good | |
+| Documentation | Fair | 6 missing sprint summaries |
+| Process Issues | Minor | Bash-to-PowerShell escaping issues |
+| Risk Management | Very Good | MSIX testing proved fix before Store submission |
+| Next Sprint Readiness | Very Good | |
+
+---
+
+## Improvements Implemented
+
+| # | Improvement | Status |
+|---|------------|--------|
+| 1 | Fix python3 hook error - created python3.cmd shim in devtools | [OK] |
+| 2 | Create launch-msix.ps1 for reliable MSIX app launching | [OK] |
+| 3 | Create 6 missing sprint summaries (13, 16, 24, 25, 26, 28) | [OK] |
+| 4 | Make sprint summary mandatory in Phase 7 (not deferrable) | [OK] |
+| 5 | Add winwright E2E testing step to Phase 5 in SPRINT_CHECKLIST.md | [OK] |
+| 6 | Fix UserPromptSubmit hook error (python3.cmd shim resolves all hookify hooks) | [OK] |
+
+---
+
+## Metrics
+
+- **Tests**: 1170 passing, 28 skipped, 1 pre-existing failure
+- **Analyze**: 0 issues
+- **MSIX**: Built, installed, launched successfully
+- **Commits**: 7 (plus retrospective)
+- **Issues closed**: #219 (F49), #221 (F51)
+- **Issue #218**: Fixed but not closed (awaiting Store resubmission verification)

--- a/docs/sprints/SPRINT_28_SUMMARY.md
+++ b/docs/sprints/SPRINT_28_SUMMARY.md
@@ -1,0 +1,20 @@
+# Sprint 28 Summary
+
+**Sprint**: Sprint 28 - MSIX Sandbox Fix + UX Improvements
+**Date**: April 2, 2026
+**Status**: [OK] Complete
+**PR**: #223
+
+## What Was Done
+Fixed the Microsoft Store certification blocker (MSIX sandbox crash at launch due to sqlite3 DLL loading) and implemented UX improvements from Sprint 27 retrospective feedback.
+
+## Key Deliverables
+- B1 (Issue #218): Replaced all hardcoded Platform.environment['APPDATA'] paths with path_provider for MSIX sandbox compatibility
+- B1 (Issue #218): Added MSIX detection (AppEnvironment.isMsixInstall) and skip Task Scheduler in MSIX context
+- B1 (Issue #218): Fixed app_identity_migration, dev_environment_seeder, and background_scan_windows_worker to use path_provider
+- F49 (Issue #219): Removed "Scan All N Accounts" button from account selection screen
+- F49 (Issue #219): View Scan History on account selection shows account selection dialog with account email in title
+- F51 (Issue #221): Background settings Scan Mode moved above Default Folders to match Manual Scan layout
+- Local MSIX testing support added (create-test-cert.ps1, store/test toggle docs)
+- Fix: Test Background Scan runs all accounts regardless of Enable Background Scanning toggle
+- Fix: Account selection dialog displays correct email and platform from cached data

--- a/mobile-app/lib/core/services/app_environment.dart
+++ b/mobile-app/lib/core/services/app_environment.dart
@@ -12,6 +12,8 @@
 /// Default: dev (development mode)
 library;
 
+import 'dart:io' show Platform;
+
 /// Application environment singleton
 class AppEnvironment {
   static const String _envKey = 'APP_ENV';
@@ -54,4 +56,17 @@ class AppEnvironment {
 
   /// Environment description for logging
   static String get description => isProd ? 'Production' : 'Development';
+
+  /// Whether the app is running from an MSIX package (Microsoft Store install).
+  ///
+  /// MSIX-installed apps run from C:\Program Files\WindowsApps\... which is
+  /// read-only and has sandbox restrictions. Task Scheduler registration and
+  /// other OS-level integrations may not work in this context.
+  ///
+  /// [NEW] Issue #218: Used to skip Task Scheduler operations in MSIX builds.
+  static bool get isMsixInstall {
+    if (!Platform.isWindows) return false;
+    final exe = Platform.resolvedExecutable.toLowerCase();
+    return exe.contains('windowsapps') || exe.contains('program files\\windowsapps');
+  }
 }

--- a/mobile-app/lib/core/services/app_identity_migration.dart
+++ b/mobile-app/lib/core/services/app_identity_migration.dart
@@ -14,7 +14,8 @@ library;
 import 'dart:io';
 
 import 'package:logger/logger.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
 
 /// Migrates app data from the old identity directory to the new one.
 ///
@@ -25,20 +26,29 @@ class AppIdentityMigration {
   static final _log = Logger();
 
   /// Old app data directory (com.example identity)
-  static String get _oldDirPath {
-    final appData = Platform.environment['APPDATA'] ?? '';
-    return path.join(appData, 'com.example', 'spam_filter_mobile');
+  /// Uses path_provider to resolve the correct base path (MSIX-safe).
+  static Future<String> _getOldDirPath() async {
+    final appSupport = await getApplicationSupportDirectory();
+    // getApplicationSupportDirectory on Windows returns:
+    //   C:\Users\{user}\AppData\Roaming\{org}\{app}
+    // We need the Roaming root to find the old com.example path.
+    // Go up 2 levels from the app support dir to get AppData\Roaming.
+    final roamingDir = appSupport.parent.parent;
+    return p.join(roamingDir.path, 'com.example', 'spam_filter_mobile');
   }
 
   /// New app data directory (MyEmailSpamFilter identity)
-  static String get _newDirPath {
-    final appData = Platform.environment['APPDATA'] ?? '';
-    return path.join(appData, 'MyEmailSpamFilter', 'MyEmailSpamFilter');
+  /// Uses path_provider to resolve the correct base path (MSIX-safe).
+  static Future<String> _getNewDirPath() async {
+    final appSupport = await getApplicationSupportDirectory();
+    // path_provider already returns the correct new identity path
+    return appSupport.path;
   }
 
   /// Marker file to indicate migration has been completed
-  static String get _migrationMarkerPath {
-    return path.join(_newDirPath, '.migration_complete');
+  static Future<String> _getMigrationMarkerPath() async {
+    final newDir = await _getNewDirPath();
+    return p.join(newDir, '.migration_complete');
   }
 
   /// Run the migration if needed.
@@ -47,8 +57,12 @@ class AppIdentityMigration {
   static Future<bool> migrateIfNeeded() async {
     if (!Platform.isWindows) return false;
 
-    final oldDir = Directory(_oldDirPath);
-    final markerFile = File(_migrationMarkerPath);
+    final oldDirPath = await _getOldDirPath();
+    final newDirPath = await _getNewDirPath();
+    final markerPath = await _getMigrationMarkerPath();
+
+    final oldDir = Directory(oldDirPath);
+    final markerFile = File(markerPath);
 
     // Skip if migration already completed
     if (await markerFile.exists()) {
@@ -60,13 +74,13 @@ class AppIdentityMigration {
     if (!await oldDir.exists()) {
       _log.d('Old app data directory not found, no migration needed');
       // Write marker so we do not check again
-      await _writeMarker(markerFile);
+      await _writeMarker(markerFile, oldDirPath: oldDirPath, newDirPath: newDirPath);
       return false;
     }
 
     _log.i('Starting app identity migration from ${oldDir.path}');
 
-    final newDir = Directory(_newDirPath);
+    final newDir = Directory(newDirPath);
     await newDir.create(recursive: true);
 
     int filesCopied = 0;
@@ -74,22 +88,22 @@ class AppIdentityMigration {
 
     try {
       // 1. Migrate database (most critical - contains accounts, settings, scan history)
-      filesCopied += await _migrateFile('spam_filter.db');
+      filesCopied += await _migrateFile('spam_filter.db', oldDirPath, newDirPath);
 
       // 2. Migrate flutter_secure_storage.dat (contains encrypted credentials)
-      filesCopied += await _migrateFile('flutter_secure_storage.dat');
+      filesCopied += await _migrateFile('flutter_secure_storage.dat', oldDirPath, newDirPath);
 
       // 3. Migrate rules directory (YAML rule files and archives)
-      filesCopied += await _migrateDirectory('rules');
+      filesCopied += await _migrateDirectory('rules', oldDirPath, newDirPath);
 
       // 4. Migrate backups directory
-      filesCopied += await _migrateDirectory('backups');
+      filesCopied += await _migrateDirectory('backups', oldDirPath, newDirPath);
 
       // 5. Migrate logs directory
-      filesCopied += await _migrateDirectory('logs');
+      filesCopied += await _migrateDirectory('logs', oldDirPath, newDirPath);
 
       // 6. Migrate credentials directory (metadata files)
-      filesCopied += await _migrateDirectory('credentials');
+      filesCopied += await _migrateDirectory('credentials', oldDirPath, newDirPath);
 
       _log.i('App identity migration complete: $filesCopied files copied');
     } catch (e) {
@@ -99,7 +113,8 @@ class AppIdentityMigration {
 
     // Write marker even if there were some errors, to avoid re-running
     // partial migrations. The old data is preserved as a fallback.
-    await _writeMarker(markerFile, filesCopied: filesCopied, errors: errors);
+    await _writeMarker(markerFile, filesCopied: filesCopied, errors: errors,
+        oldDirPath: oldDirPath, newDirPath: newDirPath);
 
     return filesCopied > 0;
   }
@@ -108,9 +123,9 @@ class AppIdentityMigration {
   /// and does NOT exist in new (do not overwrite).
   ///
   /// Returns 1 if copied, 0 if skipped.
-  static Future<int> _migrateFile(String filename) async {
-    final oldFile = File(path.join(_oldDirPath, filename));
-    final newFile = File(path.join(_newDirPath, filename));
+  static Future<int> _migrateFile(String filename, String oldDirPath, String newDirPath) async {
+    final oldFile = File(p.join(oldDirPath, filename));
+    final newFile = File(p.join(newDirPath, filename));
 
     if (!await oldFile.exists()) {
       _log.d('Migration: $filename not found in old directory, skipping');
@@ -146,9 +161,9 @@ class AppIdentityMigration {
   /// Copy all files from an old subdirectory to the new subdirectory.
   ///
   /// Returns the number of files copied.
-  static Future<int> _migrateDirectory(String dirName) async {
-    final oldSubDir = Directory(path.join(_oldDirPath, dirName));
-    final newSubDir = Directory(path.join(_newDirPath, dirName));
+  static Future<int> _migrateDirectory(String dirName, String oldDirPath, String newDirPath) async {
+    final oldSubDir = Directory(p.join(oldDirPath, dirName));
+    final newSubDir = Directory(p.join(newDirPath, dirName));
 
     if (!await oldSubDir.exists()) {
       _log.d('Migration: $dirName/ not found in old directory, skipping');
@@ -161,8 +176,8 @@ class AppIdentityMigration {
     try {
       await for (final entity in oldSubDir.list(recursive: true)) {
         if (entity is File) {
-          final relativePath = path.relative(entity.path, from: oldSubDir.path);
-          final newFile = File(path.join(newSubDir.path, relativePath));
+          final relativePath = p.relative(entity.path, from: oldSubDir.path);
+          final newFile = File(p.join(newSubDir.path, relativePath));
 
           if (await newFile.exists()) {
             // Do not overwrite existing files
@@ -190,6 +205,8 @@ class AppIdentityMigration {
     File markerFile, {
     int filesCopied = 0,
     int errors = 0,
+    String oldDirPath = '',
+    String newDirPath = '',
   }) async {
     try {
       await markerFile.parent.create(recursive: true);
@@ -197,8 +214,8 @@ class AppIdentityMigration {
         'Migration completed: ${DateTime.now().toIso8601String()}\n'
         'Files copied: $filesCopied\n'
         'Errors: $errors\n'
-        'Old path: $_oldDirPath\n'
-        'New path: $_newDirPath\n',
+        'Old path: $oldDirPath\n'
+        'New path: $newDirPath\n',
       );
     } catch (e) {
       _log.w('Failed to write migration marker: $e');

--- a/mobile-app/lib/core/services/background_scan_windows_worker.dart
+++ b/mobile-app/lib/core/services/background_scan_windows_worker.dart
@@ -52,11 +52,14 @@ class BackgroundScanWindowsWorker {
     } catch (_) {}
   }
 
-  /// Execute background scan for all enabled accounts
+  /// Execute background scan for accounts.
   ///
-  /// This method is called when the app is launched with --background-scan flag
-  /// by Windows Task Scheduler. It scans all enabled accounts and logs results.
-  static Future<bool> executeBackgroundScan() async {
+  /// When [isTest] is false (default): Only scans accounts with background
+  /// scanning enabled. Called by Task Scheduler with --background-scan flag.
+  ///
+  /// When [isTest] is true: Scans ALL accounts regardless of the enable flag.
+  /// Called by the "Test Background Scan" button in Settings.
+  static Future<bool> executeBackgroundScan({bool isTest = false}) async {
     _logger.i('Starting Windows background scan worker execution');
     await _bgLog('executeBackgroundScan() started');
 
@@ -95,18 +98,20 @@ class BackgroundScanWindowsWorker {
       int successCount = 0;
       int failureCount = 0;
 
-      // Scan each enabled account
+      // Scan accounts (all if test mode, only enabled if scheduled)
       for (final accountId in accountIds) {
         await _bgLog('Processing account: $accountId');
         try {
-          // Check if background scans enabled for this account
-          final isBackgroundEnabled =
-              await settingsStore.getEffectiveBackgroundEnabled(accountId);
+          // Skip disabled accounts unless this is a test run
+          if (!isTest) {
+            final isBackgroundEnabled =
+                await settingsStore.getEffectiveBackgroundEnabled(accountId);
 
-          if (!isBackgroundEnabled) {
-            _logger.d('Background scans disabled for account $accountId');
-            await _bgLog('Background scans disabled for $accountId, skipping');
-            continue;
+            if (!isBackgroundEnabled) {
+              _logger.d('Background scans disabled for account $accountId');
+              await _bgLog('Background scans disabled for $accountId, skipping');
+              continue;
+            }
           }
 
           // Resolve platform ID from credential store or infer from account ID

--- a/mobile-app/lib/core/services/background_scan_windows_worker.dart
+++ b/mobile-app/lib/core/services/background_scan_windows_worker.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:logger/logger.dart';
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import 'package:syncfusion_flutter_xlsio/xlsio.dart' as xlsio;
 
 import '../storage/database_helper.dart';
@@ -21,13 +22,26 @@ import '../../adapters/storage/secure_credentials_store.dart';
 class BackgroundScanWindowsWorker {
   static final Logger _logger = Logger();
 
+  /// Cached log directory path (resolved once via path_provider)
+  static String? _cachedLogDir;
+
+  /// Get log directory path using path_provider (MSIX-safe).
+  /// [UPDATED] Issue #218: Replaces Platform.environment['APPDATA'] usage.
+  static Future<String> _getLogDir() async {
+    if (_cachedLogDir != null) return _cachedLogDir!;
+    final appSupport = await getApplicationSupportDirectory();
+    final envSuffix = AppEnvironment.dataDirSuffix;
+    _cachedLogDir = '${appSupport.path}$envSuffix\\logs';
+    return _cachedLogDir!;
+  }
+
   /// File-based logger for headless background mode diagnostics
   static Future<void> _bgLog(String message) async {
     try {
-      final envSuffix = AppEnvironment.dataDirSuffix;
+      final logDir = await _getLogDir();
       final logPrefix = AppEnvironment.logPrefix;
       final logFile = File(
-        '${Platform.environment['APPDATA']}\\MyEmailSpamFilter\\MyEmailSpamFilter$envSuffix\\logs\\${logPrefix}background_scan_v0.5.1.log',
+        '$logDir\\${logPrefix}background_scan_v0.5.1.log',
       );
       final timestamp = DateTime.now().toIso8601String();
       await logFile.parent.create(recursive: true);
@@ -275,9 +289,8 @@ class BackgroundScanWindowsWorker {
       if (!debugCsvEnabled) return;
 
       // Export to environment-aware AppData directory (ADR-0035)
-      final envSuffix = AppEnvironment.dataDirSuffix;
-      final exportDir = '${Platform.environment['APPDATA']}'
-          '\\MyEmailSpamFilter\\MyEmailSpamFilter$envSuffix\\logs';
+      // [UPDATED] Issue #218: Use path_provider for MSIX sandbox compatibility
+      final exportDir = await _getLogDir();
 
       // Ensure directory exists
       final dir = Directory(exportDir);

--- a/mobile-app/lib/core/services/dev_environment_seeder.dart
+++ b/mobile-app/lib/core/services/dev_environment_seeder.dart
@@ -9,6 +9,7 @@ library;
 
 import 'dart:io';
 import 'package:logger/logger.dart';
+import 'package:path_provider/path_provider.dart';
 import 'app_environment.dart';
 
 /// Seeds the development data directory from production data
@@ -22,14 +23,19 @@ class DevEnvironmentSeeder {
   /// 2. Dev data directory has no database
   /// 3. Production database exists
   /// 4. .dev_seeded marker does not exist
+  ///
+  /// [UPDATED] Issue #218: Uses path_provider instead of Platform.environment
+  /// for MSIX sandbox compatibility.
   static Future<void> seedIfNeeded() async {
     if (!AppEnvironment.isDev) return;
 
-    final appData = Platform.environment['APPDATA'];
-    if (appData == null) return;
-
-    final prodDir = '$appData\\MyEmailSpamFilter\\MyEmailSpamFilter';
-    final devDir = '$appData\\MyEmailSpamFilter\\MyEmailSpamFilter_Dev';
+    // Use path_provider to resolve paths (MSIX-safe)
+    final appSupport = await getApplicationSupportDirectory();
+    // appSupport is already the dev path (with _Dev suffix applied by AppPaths later)
+    // but we need the base path without suffix to find prod data
+    final basePath = appSupport.parent.path; // MyEmailSpamFilter parent
+    final prodDir = '$basePath\\MyEmailSpamFilter';
+    final devDir = '$basePath\\MyEmailSpamFilter_Dev';
     final markerFile = File('$devDir\\.dev_seeded');
     final devDb = File('$devDir\\spam_filter.db');
     final prodDb = File('$prodDir\\spam_filter.db');

--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -1,9 +1,10 @@
-import 'dart:io' show File, FileMode, Platform, exit;
+import 'dart:io' show Directory, File, FileMode, Platform, exit;
 import 'package:flutter/foundation.dart' show kReleaseMode;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'core/providers/rule_set_provider.dart';
 import 'core/providers/email_scan_provider.dart';
@@ -44,9 +45,13 @@ void main(List<String> args) async {
   // If running in background mode (launched by Task Scheduler), execute scan and exit
   if (BackgroundModeService.isBackgroundMode) {
     // Use file-based logging since headless mode has no console
+    // [UPDATED] Issue #218: Use path_provider for MSIX sandbox compatibility
+    final appSupport = await getApplicationSupportDirectory();
     final envSuffix = AppEnvironment.dataDirSuffix;
     final logPrefix = AppEnvironment.logPrefix;
-    final logFile = File('${Platform.environment['APPDATA']}\\MyEmailSpamFilter\\MyEmailSpamFilter$envSuffix\\logs\\${logPrefix}background_scan_v0.5.1.log');
+    final logDir = Directory('${appSupport.path}$envSuffix\\logs');
+    await logDir.create(recursive: true);
+    final logFile = File('${logDir.path}\\${logPrefix}background_scan_v0.5.1.log');
     Future<void> bgLog(String message) async {
       try {
         final timestamp = DateTime.now().toIso8601String();
@@ -118,10 +123,11 @@ void main(List<String> args) async {
     await notificationService.initialize();
     Logger().i('Windows notifications initialized');
 
-    // Only manage Task Scheduler in release mode - in debug/flutter run mode,
-    // Platform.resolvedExecutable points to a temporary runner path that will
-    // not exist after the debug session ends, creating a broken scheduled task.
-    if (kReleaseMode) {
+    // Only manage Task Scheduler in release mode and non-MSIX installs.
+    // In debug mode: Platform.resolvedExecutable points to a temporary runner path.
+    // In MSIX: The exe is in read-only WindowsApps dir; Task Scheduler cannot work.
+    // [UPDATED] Issue #218: Skip Task Scheduler in MSIX context.
+    if (kReleaseMode && !AppEnvironment.isMsixInstall) {
       // Verify and repair task scheduler executable path after rebuild
       try {
         final repaired = await WindowsTaskSchedulerService.verifyAndRepairTaskPath();
@@ -154,7 +160,11 @@ void main(List<String> args) async {
         Logger().w('Background scan task verification failed: $e');
       }
     } else {
-      Logger().i('Skipping Task Scheduler management in debug mode');
+      if (AppEnvironment.isMsixInstall) {
+        Logger().i('Skipping Task Scheduler management in MSIX install');
+      } else {
+        Logger().i('Skipping Task Scheduler management in debug mode');
+      }
     }
   }
 

--- a/mobile-app/lib/ui/screens/account_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/account_selection_screen.dart
@@ -1,20 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
-import 'package:provider/provider.dart';
 import '../../adapters/storage/secure_credentials_store.dart';
 import '../../adapters/email_providers/platform_registry.dart';
 import '../../adapters/email_providers/spam_filter_platform.dart';
-import '../../core/providers/email_scan_provider.dart';
-import '../../core/providers/rule_set_provider.dart';
-import '../../core/services/email_scanner.dart';
-import '../../core/storage/settings_store.dart';
 import '../../main.dart' show routeObserver;
 import '../widgets/skeleton_loader.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/error_display.dart';
 import '../widgets/app_bar_with_exit.dart';
 import 'platform_selection_screen.dart';
-import 'results_display_screen.dart';
 import 'scan_history_screen.dart';
 import 'scan_progress_screen.dart';
 import 'settings_screen.dart';
@@ -392,100 +386,6 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
     ).then((_) => _loadSavedAccounts()); // Refresh accounts on return
   }
 
-  /// F7: Scan all saved accounts sequentially
-  Future<void> _scanAllAccounts() async {
-    if (_savedAccounts.length < 2) {
-      // Only one account - just scan it directly
-      if (_savedAccounts.isNotEmpty) {
-        _selectAccount(_savedAccounts.first);
-      }
-      return;
-    }
-
-    final scanProvider = Provider.of<EmailScanProvider>(context, listen: false);
-    final ruleProvider = Provider.of<RuleSetProvider>(context, listen: false);
-    final settingsStore = SettingsStore();
-
-    // Reset provider for fresh multi-account scan
-    scanProvider.reset();
-
-    // Resolve all account data first
-    final accounts = <({String accountId, String platformId, String email})>[];
-    for (final accountId in _savedAccounts) {
-      final platformId = await _credStore.getPlatformId(accountId) ?? '';
-      if (platformId.isNotEmpty) {
-        accounts.add((accountId: accountId, platformId: platformId, email: accountId));
-      }
-    }
-
-    if (accounts.isEmpty) return;
-
-    // Use first account's platform info for results screen (display only)
-    final firstAccount = accounts.first;
-    final firstPlatformName = _getPlatformName(firstAccount.platformId);
-
-    // Start scan and navigate to results immediately
-    scanProvider.startScan(totalEmails: 0, persist: false);
-    final scanMode = await settingsStore.getAccountManualScanMode(firstAccount.accountId) ?? ScanMode.readOnly;
-    scanProvider.initializeScanMode(mode: scanMode);
-
-    if (!mounted) return;
-
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => ResultsDisplayScreen(
-          platformId: firstAccount.platformId,
-          platformDisplayName: 'All Accounts ($firstPlatformName + ${accounts.length - 1} more)',
-          accountId: firstAccount.accountId,
-          accountEmail: '${accounts.length} accounts',
-        ),
-      ),
-    ).then((_) => _loadSavedAccounts());
-
-    // Scan each account sequentially
-    var totalErrors = 0;
-    for (var i = 0; i < accounts.length; i++) {
-      final account = accounts[i];
-      _logger.i('[F7] Scanning account ${i + 1}/${accounts.length}: ${account.email}');
-
-      try {
-        // Load per-account settings
-        final daysBack = await settingsStore.getEffectiveDaysBack(account.accountId, isBackground: false);
-        final savedFolders = await settingsStore.getAccountManualScanFolders(account.accountId);
-        final foldersToScan = (savedFolders != null && savedFolders.isNotEmpty)
-            ? savedFolders
-            : ['INBOX'];
-
-        scanProvider.setSelectedFolders(foldersToScan, accountId: account.accountId);
-        scanProvider.setCurrentAccountId(account.accountId);
-
-        final scanner = EmailScanner(
-          platformId: account.platformId,
-          accountId: account.accountId,
-          ruleSetProvider: ruleProvider,
-          scanProvider: scanProvider,
-        );
-
-        await scanner.scanInbox(daysBack: daysBack, folderNames: foldersToScan);
-        _logger.i('[F7] Account ${account.email} scan completed');
-      } catch (e) {
-        _logger.e('[F7] Account ${account.email} scan failed: $e');
-        totalErrors++;
-        // Continue with next account - do not block
-      }
-    }
-
-    // Mark scan as complete
-    try {
-      await scanProvider.completeScan();
-    } catch (e) {
-      _logger.w('[F7] completeScan failed: $e');
-    }
-
-    _logger.i('[F7] Multi-account scan complete: ${accounts.length} accounts, $totalErrors errors');
-  }
-
   /// Navigate to platform selection to add new account
   void _addNewAccount() {
     Navigator.push<bool>(
@@ -568,19 +468,71 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
   }
 
   /// Build scan history icon button for AppBar
+  /// [UPDATED] ISSUE #219: Show account selection dialog before navigating
   Widget _buildHistoryButton() {
     return IconButton(
       icon: const Icon(Icons.history),
       tooltip: 'View Scan History',
-      onPressed: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => const ScanHistoryScreen(),
-          ),
-        );
-      },
+      onPressed: _openScanHistory,
     );
+  }
+
+  /// Navigate to scan history with account selection
+  /// [NEW] ISSUE #219: Reuses same dialog pattern as _openSettings()
+  void _openScanHistory() async {
+    if (_savedAccounts.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please add an email account first')),
+      );
+      return;
+    }
+
+    // Show account selection dialog
+    final selected = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Select Account'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: _savedAccounts.map((accountId) {
+            final parts = accountId.split('-');
+            final platformId = parts[0];
+            final email = parts.sublist(1).join('-');
+
+            return ListTile(
+              leading: Icon(_getPlatformIcon(platformId)),
+              title: Text(email),
+              subtitle: Text(_getPlatformDisplayName(platformId)),
+              onTap: () => Navigator.pop(ctx, accountId),
+            );
+          }).toList(),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+
+    if (selected != null && mounted) {
+      final parts = selected.split('-');
+      final platformId = parts[0];
+      final email = parts.sublist(1).join('-');
+
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => ScanHistoryScreen(
+            accountId: selected,
+            accountEmail: email,
+            platformId: platformId,
+            platformDisplayName: _getPlatformDisplayName(platformId),
+          ),
+        ),
+      );
+    }
   }
 
   /// Delete account with confirmation dialog
@@ -724,23 +676,11 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Select an account to scan, or scan all accounts at once',
+                  'Select an account to scan',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: Colors.grey[600],
                       ),
                 ),
-                // F7: Scan All button (only show if 2+ accounts)
-                if (_savedAccounts.length >= 2) ...[
-                  const SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    child: FilledButton.icon(
-                      icon: const Icon(Icons.play_circle_outline),
-                      label: Text('Scan All ${_savedAccounts.length} Accounts'),
-                      onPressed: _scanAllAccounts,
-                    ),
-                  ),
-                ],
               ],
             ),
           ),

--- a/mobile-app/lib/ui/screens/account_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/account_selection_screen.dart
@@ -408,29 +408,21 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
     });
   }
 
-  /// Navigate to settings screen
-  /// [UPDATED] ISSUE #123: Settings requires accountId, show account selector dialog
-  void _openSettings() async {
-    if (_savedAccounts.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please add an email account first')),
-      );
-      return;
-    }
-
-    // Show account selection dialog
-    final selected = await showDialog<String>(
+  /// Show account selection dialog and return the selected accountId.
+  /// Reused by Settings and Scan History navigation.
+  /// [UPDATED] Issue #219: Uses cached AccountDisplayData for correct display.
+  Future<String?> _showAccountSelectionDialog() async {
+    return showDialog<String>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Select Account'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: _savedAccounts.map((accountId) {
-            // Extract platform and email from accountId (format: "platform-email")
-            final parts = accountId.split('-');
-            final platformId = parts[0];
-            final email = parts.sublist(1).join('-');
-            
+            final displayData = _accountDataCache[accountId];
+            final email = displayData?.email ?? accountId;
+            final platformId = displayData?.platformId ?? '';
+
             return ListTile(
               leading: Icon(_getPlatformIcon(platformId)),
               title: Text(email),
@@ -447,6 +439,19 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
         ],
       ),
     );
+  }
+
+  /// Navigate to settings screen
+  /// [UPDATED] ISSUE #123: Settings requires accountId, show account selector dialog
+  void _openSettings() async {
+    if (_savedAccounts.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please add an email account first')),
+      );
+      return;
+    }
+
+    final selected = await _showAccountSelectionDialog();
 
     if (selected != null && mounted) {
       Navigator.push(
@@ -478,7 +483,7 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
   }
 
   /// Navigate to scan history with account selection
-  /// [NEW] ISSUE #219: Reuses same dialog pattern as _openSettings()
+  /// [NEW] ISSUE #219: Reuses shared account selection dialog
   void _openScanHistory() async {
     if (_savedAccounts.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -487,39 +492,12 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
       return;
     }
 
-    // Show account selection dialog
-    final selected = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Select Account'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: _savedAccounts.map((accountId) {
-            final parts = accountId.split('-');
-            final platformId = parts[0];
-            final email = parts.sublist(1).join('-');
-
-            return ListTile(
-              leading: Icon(_getPlatformIcon(platformId)),
-              title: Text(email),
-              subtitle: Text(_getPlatformDisplayName(platformId)),
-              onTap: () => Navigator.pop(ctx, accountId),
-            );
-          }).toList(),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Cancel'),
-          ),
-        ],
-      ),
-    );
+    final selected = await _showAccountSelectionDialog();
 
     if (selected != null && mounted) {
-      final parts = selected.split('-');
-      final platformId = parts[0];
-      final email = parts.sublist(1).join('-');
+      final displayData = _accountDataCache[selected];
+      final email = displayData?.email ?? selected;
+      final platformId = displayData?.platformId ?? '';
 
       Navigator.push(
         context,

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -97,7 +97,10 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBarWithExit(
-        title: const Text('Scan History'),
+        // [UPDATED] ISSUE #219: Show account email in title when filtered
+        title: Text(widget.accountEmail != null
+            ? 'Scan History - ${widget.accountEmail}'
+            : 'Scan History'),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),

--- a/mobile-app/lib/ui/screens/settings_screen.dart
+++ b/mobile-app/lib/ui/screens/settings_screen.dart
@@ -751,7 +751,7 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
 
     try {
       if (Platform.isWindows) {
-        final success = await BackgroundScanWindowsWorker.executeBackgroundScan();
+        final success = await BackgroundScanWindowsWorker.executeBackgroundScan(isTest: true);
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/mobile-app/lib/ui/screens/settings_screen.dart
+++ b/mobile-app/lib/ui/screens/settings_screen.dart
@@ -666,6 +666,18 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
           },
         ),
         const SizedBox(height: 24),
+        // [UPDATED] ISSUE #221: Scan Mode moved above Scan Range and Default Folders
+        // to match Manual Scan tab section order
+        _buildSectionHeader('Scan Mode'),
+        _buildScanModeSelector(
+          value: _backgroundScanMode,
+          onChanged: (mode) async {
+            setState(() => _backgroundScanMode = mode);
+            // [UPDATED] ISSUE #123: Save per-account background scan mode
+            await _settingsStore.setAccountBackgroundScanMode(widget.accountId, mode);
+          },
+        ),
+        const SizedBox(height: 24),
         // [NEW] ISSUE #153: Scan range (days back / all emails)
         _buildSectionHeader('Scan Range'),
         _buildScanRangeSelector(
@@ -683,16 +695,6 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
             setState(() => _backgroundScanFolders = folders);
             // [UPDATED] ISSUE #123: Save per-account background scan folders
             await _settingsStore.setAccountBackgroundScanFolders(widget.accountId, folders);
-          },
-        ),
-        const SizedBox(height: 24),
-        _buildSectionHeader('Scan Mode'),
-        _buildScanModeSelector(
-          value: _backgroundScanMode,
-          onChanged: (mode) async {
-            setState(() => _backgroundScanMode = mode);
-            // [UPDATED] ISSUE #123: Save per-account background scan mode
-            await _settingsStore.setAccountBackgroundScanMode(widget.accountId, mode);
           },
         ),
         const SizedBox(height: 24),

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -85,6 +85,8 @@ msix_config:
   msix_version: 0.5.1.0
   logo_path: assets/icon/icon.png
   capabilities: internetClient, internetClientServer, privateNetworkClientServer
+  # For Store submission: store: true, install_certificate: false
+  # For local MSIX testing: store: false, install_certificate: true
   store: true
   install_certificate: false
 

--- a/mobile-app/scripts/create-test-cert.ps1
+++ b/mobile-app/scripts/create-test-cert.ps1
@@ -1,0 +1,24 @@
+# Create a self-signed certificate for local MSIX testing
+# This certificate matches the publisher CN in pubspec.yaml msix_config
+
+$subject = "CN=84EA8722-0CA5-4EC0-9B10-07EE79B66062"
+
+# Check if cert already exists
+$existing = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object { $_.Subject -eq $subject }
+if ($existing) {
+    Write-Host "Certificate already exists: $($existing.Thumbprint)"
+    Write-Host "To use: dart run msix:create --store false --certificate-subject '$subject'"
+    exit 0
+}
+
+# Create self-signed certificate
+$cert = New-SelfSignedCertificate `
+    -Type Custom `
+    -Subject $subject `
+    -KeyUsage DigitalSignature `
+    -FriendlyName "MyEmailSpamFilter Local Test" `
+    -CertStoreLocation "Cert:\CurrentUser\My" `
+    -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+
+Write-Host "Certificate created: $($cert.Thumbprint)"
+Write-Host "To use: dart run msix:create --store false --certificate-subject '$subject'"

--- a/mobile-app/scripts/launch-msix.ps1
+++ b/mobile-app/scripts/launch-msix.ps1
@@ -1,0 +1,68 @@
+# Launch the MSIX-installed MyEmailSpamFilter app
+#
+# Usage:
+#   .\launch-msix.ps1           # Launch the app
+#   .\launch-msix.ps1 -Uninstall  # Remove the MSIX package
+#   .\launch-msix.ps1 -Install <path>  # Install an MSIX and launch
+
+param(
+    [switch]$Uninstall,
+    [string]$Install
+)
+
+$appName = "KimmeyConsulting-Ohio.MyEmailSpamFilter"
+
+# Find the installed package
+$pkg = Get-AppxPackage -Name $appName -ErrorAction SilentlyContinue
+
+if ($Uninstall) {
+    if ($pkg) {
+        Write-Host "Removing $appName..."
+        $pkg | Remove-AppxPackage
+        Write-Host "Removed."
+    } else {
+        Write-Host "Package not installed."
+    }
+    exit 0
+}
+
+if ($Install) {
+    if (-not (Test-Path $Install)) {
+        Write-Host "File not found: $Install" -ForegroundColor Red
+        exit 1
+    }
+    # Remove existing install first
+    if ($pkg) {
+        Write-Host "Removing existing install..."
+        $pkg | Remove-AppxPackage
+        Start-Sleep -Seconds 2
+    }
+    Write-Host "Installing $Install..."
+    Add-AppxPackage -Path $Install
+    # Refresh package reference
+    $pkg = Get-AppxPackage -Name $appName -ErrorAction SilentlyContinue
+}
+
+if (-not $pkg) {
+    Write-Host "MyEmailSpamFilter is not installed as MSIX." -ForegroundColor Red
+    Write-Host "Install with: .\launch-msix.ps1 -Install <path-to-msix>"
+    exit 1
+}
+
+# Get the app entry point from the manifest
+$manifest = Get-AppxPackageManifest $pkg
+$appId = $manifest.Package.Applications.Application.Id
+
+# Launch via explorer (most reliable method on Windows)
+$aumid = "$($pkg.PackageFamilyName)!$appId"
+Write-Host "Launching: $aumid"
+explorer.exe "shell:AppsFolder\$aumid"
+
+# Wait and verify
+Start-Sleep -Seconds 5
+$process = Get-Process -Name "MyEmailSpamFilter" -ErrorAction SilentlyContinue
+if ($process) {
+    Write-Host "App running (PID: $($process.Id))" -ForegroundColor Green
+} else {
+    Write-Host "App may not have launched. Check Start Menu for MyEmailSpamFilter." -ForegroundColor Yellow
+}


### PR DESCRIPTION
## Summary
- **fix**: MSIX sandbox crash at launch (Issue #218) - replaced all hardcoded `Platform.environment['APPDATA']` paths with `path_provider`, added MSIX detection to skip Task Scheduler
- **feat**: Remove "Scan All Accounts" button, add account selection dialog to View Scan History (Issue #219)
- **feat**: Background settings: Scan Mode moved above Default Folders (Issue #221)
- **fix**: Account selection dialog shows correct email/platform from cached data
- **fix**: Test Background Scan runs all accounts regardless of enable toggle

## MSIX Sandbox Fix (B1, Issue #218)
- 6 occurrences of `Platform.environment['APPDATA']` replaced with `path_provider` in 4 files
- `AppEnvironment.isMsixInstall` detects WindowsApps exe path
- Task Scheduler registration skipped in MSIX context
- sqlite3 DLL bundling already works via build hooks (no changes needed)
- MSIX package built, installed, and launched successfully in local testing

## Test plan
- [x] `flutter analyze` - 0 issues
- [x] `flutter test` - 1170 passing (1 pre-existing failure)
- [x] Windows dev build - launches and runs correctly
- [x] MSIX build (`dart run msix:create`) - succeeds
- [x] MSIX install and launch - no crash, database loads
- [x] Scan History shows account email in title
- [x] Account selection dialog shows correct email/platform
- [x] "Scan All Accounts" button removed
- [x] Background settings reordered (Scan Mode above Folders)
- [x] Test Background Scan works with background scanning disabled
- [x] Manual testing complete

Closes #219, Closes #221

Generated with [Claude Code](https://claude.com/claude-code)