### PR TITLE
Sprint 29: UX + Quality + Features (F50, F48, F46, F42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 - **feat**: Scan History enhancements - multi-account combined view, account/type filters, totals with tooltips, retention days in title (F48, Issue #212)
 - **feat**: Default rule set creation - seed from bundled YAML on fresh install, Reset to Defaults button in Settings (F46, Issue #208)
 - **test**: Add tests for email_scanner, default_rule_set_service, yaml_service parse methods (F42, Issue #203)
+- **fix**: YAML round-trip test path after rules moved to assets/rules/ - fixes pre-existing test failure
 - **docs**: Backlog refinement - removed completed items from ALL_SPRINTS_MASTER_PLAN.md
 
 ### 2026-04-02 (Sprint 28 - MSIX Sandbox Fix + UX Improvements)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 - **feat**: Scan History enhancements - multi-account combined view, account/type filters, totals with tooltips, retention days in title (F48, Issue #212)
 - **feat**: Default rule set creation - seed from bundled YAML on fresh install, Reset to Defaults button in Settings (F46, Issue #208)
 - **test**: Add tests for email_scanner, default_rule_set_service, yaml_service parse methods (F42, Issue #203)
+- **fix**: Results screen and email detail popup now support text selection (F50 testing feedback)
+- **fix**: Account setup dialogs (AOL, Gmail, platform selection) now support text selection (F50 testing feedback)
+- **fix**: Scan History account filter uses configured accounts, shows when multiple accounts exist (F48 testing feedback)
+- **fix**: Manual Scan title shows account email instead of platform name
 - **fix**: YAML round-trip test path after rules moved to assets/rules/ - fixes pre-existing test failure
 - **docs**: Backlog refinement - removed completed items from ALL_SPRINTS_MASTER_PLAN.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 
 ## [Unreleased]
 
+### 2026-04-03 (Sprint 29 - UX + Quality + Features)
+- **feat**: Make all page text selectable and copyable across 21 screens (F50, Issue #220)
+- **feat**: Scan History enhancements - multi-account combined view, account/type filters, totals with tooltips, retention days in title (F48, Issue #212)
+- **feat**: Default rule set creation - seed from bundled YAML on fresh install, Reset to Defaults button in Settings (F46, Issue #208)
+- **test**: Add tests for email_scanner, default_rule_set_service, yaml_service parse methods (F42, Issue #203)
+- **docs**: Backlog refinement - removed completed items from ALL_SPRINTS_MASTER_PLAN.md
+
 ### 2026-04-02 (Sprint 28 - MSIX Sandbox Fix + UX Improvements)
 - **fix**: Replace all hardcoded Platform.environment['APPDATA'] paths with path_provider for MSIX sandbox compatibility (B1, Issue #218)
 - **fix**: Add MSIX detection (AppEnvironment.isMsixInstall) and skip Task Scheduler in MSIX context (B1, Issue #218)

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -150,6 +150,13 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - All variants must run simultaneously without rebuild on same machine/device
 - [Detail](#f52-multi-variant-side-by-side-install)
 
+**F53. Add block rule for top-level domain .cc (~0.5h) Priority 60**
+- Phase: Core Feature
+- Platform: All
+- Add `@.*\.cc$` block rule pattern to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern at line 1568)
+- Target: Sprint 30
+- Quick win, similar to other TLD blocks
+
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance
 - Platform: All

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -153,7 +153,7 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 **F53. Add block rules for top-level domains .cc and .ne (~0.5h) Priority 60**
 - Phase: Core Feature
 - Platform: All
-- Add `@.*\.cc$` and `@.*\.ne$` block rule patterns to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern)
+- Add `@.*\.cc$` (.cc = Cocos (Keeling) Islands) and `@.*\.ne$` (.ne = Nigeria) block rule patterns to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern)
 - Target: Sprint 30
 - Quick win, similar to other TLD blocks
 

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -150,10 +150,10 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - All variants must run simultaneously without rebuild on same machine/device
 - [Detail](#f52-multi-variant-side-by-side-install)
 
-**F53. Add block rule for top-level domain .cc (~0.5h) Priority 60**
+**F53. Add block rules for top-level domains .cc and .ne (~0.5h) Priority 60**
 - Phase: Core Feature
 - Platform: All
-- Add `@.*\.cc$` block rule pattern to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern at line 1568)
+- Add `@.*\.cc$` and `@.*\.ne$` block rule patterns to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern)
 - Target: Sprint 30
 - Quick win, similar to other TLD blocks
 

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -93,6 +93,7 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 | 26 | docs/sprints/SPRINT_26_RETROSPECTIVE.md | [OK] Complete | Mar 22-24, 2026 |
 | 27 | docs/sprints/SPRINT_27_RETROSPECTIVE.md | [OK] Complete | Mar 29 - Apr 2, 2026 |
 | 28 | docs/sprints/SPRINT_28_RETROSPECTIVE.md | [OK] Complete | Apr 2, 2026 |
+| 29 | docs/sprints/SPRINT_29_RETROSPECTIVE.md | [OK] Complete | Apr 3-13, 2026 |
 
 **Key Achievements**: See CHANGELOG.md for detailed feature history.
 
@@ -100,19 +101,18 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 
 ## Last Completed Sprint
 
-**Sprint 28** (April 2, 2026)
-- **Bug Fix**: B1 MSIX sandbox crash at launch - replaced hardcoded APPDATA paths with path_provider (Issue #218)
-- **Features**: F49 Remove Scan All Accounts + account-specific Scan History (Issue #219), F51 Background settings reorder (Issue #221)
-- **Bug Fixes**: Account selection dialog display, Test Background Scan runs all accounts
-- **MSIX**: Built, installed, launched successfully in local testing
-- **Process**: Sprint summary made mandatory in Phase 7, winwright E2E added to Phase 5, python3 hook fix
-- **Retrospective**: docs/sprints/SPRINT_28_RETROSPECTIVE.md
+**Sprint 29** (April 3-13, 2026)
+- **Features**: F50 selectable text on all 21 screens (Issue #220), F48 Scan History multi-account with filters/totals (Issue #212), F46 default rule set creation with reset option (Issue #208)
+- **Testing**: F42 +53 new tests (Issue #203), fixed pre-existing test failure, 1223 passing with 0 failures
+- **Testing Feedback**: 6 fixes (results/dialog text selection, account filter, totals alignment, nav cleanup, scan title)
+- **Backlog**: Added F52-F56, backlog refinement cleanup
+- **Retrospective**: docs/sprints/SPRINT_29_RETROSPECTIVE.md
 
 ---
 
 ## Next Sprint Candidates
 
-**Last Reviewed**: April 3, 2026 (Backlog refinement)
+**Last Reviewed**: April 13, 2026 (Sprint 29 retrospective)
 
 All incomplete items in relative priority order. Priority in increments of 10; items that can sprint together in increments of 2. HOLD items grouped at bottom. See [Feature and Bug Details](#feature-and-bug-details) for deep-dive specs. See [BACKLOG_REFINEMENT.md](BACKLOG_REFINEMENT.md) for presentation format rules.
 
@@ -122,26 +122,13 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 
 ### Core App
 
-**F42. Test coverage gaps - medium+ priority uncovered files (Issue #203) Priority 54**
-- Phase: Quality and Testing
-- Platform: All
-- On Hold - remaining test gaps from F32 analysis
+**~~F42. Test coverage gaps (Issue #203)~~** [OK] Complete (Sprint 29, +53 tests)
 
-**F46. Default rule set creation (~6-8h) Priority 74**
-- Phase: Core Feature
-- Platform: All
-- Create a default set of rules including all top-level domain rules and all Entire Domain rules
+**~~F46. Default rule set creation (Issue #208)~~** [OK] Complete (Sprint 29)
 
-**F48. Scan History enhancements - multi-account, filters, totals (Issue #212) (~6-8h) Priority 78**
-- Phase: Core Feature
-- Platform: All
-- Combine all accounts, account filters, totals with tooltips, retention days in title
-- Follow-up to F7 Multi-Account Scanning
+**~~F48. Scan History enhancements (Issue #212)~~** [OK] Complete (Sprint 29)
 
-**F50. Make all page text selectable and copyable to clipboard (Issue #220) (~4-6h) Priority 82**
-- Phase: UX Improvement
-- Platform: All
-- Sprint 27 retrospective feedback: extend existing selectable text pattern to all screens
+**~~F50. Make all page text selectable and copyable (Issue #220)~~** [OK] Complete (Sprint 29)
 
 **F52. Multi-variant side-by-side install across all stores (~16-24h) Priority 90**
 - Phase: Build and Release Infrastructure

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -150,12 +150,14 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - All variants must run simultaneously without rebuild on same machine/device
 - [Detail](#f52-multi-variant-side-by-side-install)
 
-**F53. Add block rules for top-level domains .cc and .ne (~0.5h) Priority 60**
+**F53. Add block rules for top-level domains .cc and .ne (~1h) Priority 60**
 - Phase: Core Feature
 - Platform: All
-- Add `@.*\.cc$` (.cc = Cocos (Keeling) Islands) and `@.*\.ne$` (.ne = Nigeria) block rule patterns to bundled rules.yaml (mirrors existing `@.*\.ru$` pattern)
+- Add `@.*\.cc$` (.cc = Cocos (Keeling) Islands) and `@.*\.ne$` (.ne = Nigeria) block rule patterns
+- Update bundled rules.yaml asset (new user default bundle)
+- Add to current user's rules database (migration or runtime insert for existing installs)
+- Mirrors existing `@.*\.ru$` pattern
 - Target: Sprint 30
-- Quick win, similar to other TLD blocks
 
 **F54. Add icon to Select Account screen icon row (~1-2h) Priority 64**
 - Phase: UX Improvement

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -165,6 +165,25 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Needs: icon choice, tooltip/label, navigation target
 - Design decision: what action should this trigger? (account management, add account, etc.)
 
+**F56. Manual rule creation UI - block and safe sender rules from user input (~10-14h) Priority 68**
+- Phase: Core Feature
+- Platform: All
+- Add UI for creating rules directly from user input (not just from scan results)
+- Block rules (4 types):
+  - Top-level domain: user enters TLD (e.g., .cc, .ru) and app creates `@.*\.cc$` pattern
+  - Exact domain: user pastes email address or domain string, app extracts domain and creates `@domain\.com$` pattern with confirmation
+  - Entire domain: user pastes email address, domain, or URL, app extracts domain and creates `@(?:[a-z0-9-]+\.)*domain\.com$` subdomain-matching pattern with confirmation
+  - Exact email: user enters email address, app validates format, creates `^user@domain\.com$` pattern with confirmation
+- Safe sender rules (3 types, no TLD):
+  - Exact domain: same as block but adds to safe senders
+  - Entire domain: same as block but adds to safe senders
+  - Exact email: same as block but adds to safe senders
+- App should parse and extract domain from various input formats: email address, bare domain, URL with protocol, URL with path
+- Validation: email format check, domain format check, warn if TLD-only for safe senders
+- Confirmation dialog showing generated pattern before saving
+- Accessible from Manage Rules and Manage Safe Senders screens
+- Related: F35 (rule editing UI), F25 (rule testing UI enhancements)
+
 **F55. Screen navigation consistency - linear flow + push/pop icons (~4-6h) Priority 66**
 - Phase: UX Improvement
 - Platform: All

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -4,7 +4,7 @@
 
 **Audience**: Claude Code models planning sprints; User prioritizing future work
 
-**Last Updated**: April 2, 2026 (Sprint 28 retrospective)
+**Last Updated**: April 3, 2026 (Backlog refinement)
 
 ## How to Maintain This Document
 
@@ -112,64 +112,25 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 
 ## Next Sprint Candidates
 
-**Last Reviewed**: April 2, 2026 (Sprint 28 retrospective)
+**Last Reviewed**: April 3, 2026 (Backlog refinement)
 
 All incomplete items in relative priority order. Priority in increments of 10; items that can sprint together in increments of 2. HOLD items grouped at bottom. See [Feature and Bug Details](#feature-and-bug-details) for deep-dive specs. See [BACKLOG_REFINEMENT.md](BACKLOG_REFINEMENT.md) for presentation format rules.
 
 ### Windows Store Readiness
 
-**~~B1. MSIX sandbox crash at launch - File system error (Issue #218) (~10h)~~** [OK] Complete (Sprint 28)
-- Awaiting Microsoft Store resubmission and certification verification
-
-**~~WS-B1. MSIX config fixes (~1h)~~** [OK] Complete (Sprint 23)
-
-**~~WS-B3. MSIX signing strategy ADR (~2h)~~** [OK] Complete (Sprint 23, ADR-0036)
-
-**~~F28. App icon and branding finalization (~2-4h)~~** [OK] Complete (Sprint 23, ADR-0031)
-
-**~~F29. Register myemailspamfilter.com domain (~1h)~~** [OK] Complete (Sprint 23, Issue #166)
-
-**~~WS-B4. Privacy policy - write, host, and publish (~4-8h)~~** [OK] Complete (Sprint 24, Issue #197)
-
-**~~WS-I1. Store listing assets (~3-4h)~~** [OK] Complete (Sprint 24, Issue #197)
-
-**~~WS. Microsoft Partner Center account setup and first submission (~2-4h)~~** [OK] Complete (Sprint 24, Issue #197)
+**B1. MSIX sandbox crash at launch (Issue #218) -- [OK] Fixed (Sprint 28), awaiting Store certification**
 
 ### Core App
-
-**~~F40. Safe sender matches showing in results for Gmail IMAP (Issue #198)~~** [OK] Complete (Sprint 25)
-
-**~~F30. Safe Senders "Exact Domain" filter shows 0 results~~** [OK] Complete (Sprint 25)
-
-**~~F41. Safe sender emails in Bulk Mail not moved to safe sender folder (Issue #201)~~** [OK] Complete (Sprint 25, diagnostic logging added)
-
-**~~F31. Background scan task deleted on rebuild~~** [OK] Complete (Sprint 25)
-
-**~~F32. Test coverage analysis~~** [OK] Complete (Sprint 25, 28.9% baseline, Issue #203 for remaining gaps)
 
 **F42. Test coverage gaps - medium+ priority uncovered files (Issue #203) Priority 54**
 - Phase: Quality and Testing
 - Platform: All
 - On Hold - remaining test gaps from F32 analysis
 
-**~~F34. Live Scan: in-progress and completed status indicator~~** [OK] Complete (Sprint 25)
-
-**~~F38. Live Scan: re-process emails after rule changes~~** [OK] Complete (Sprint 25)
-
-**~~F43. Folder settings selection UX~~** [OK] Complete (Sprint 26)
-
-**~~F44. Add "Go to View Scan History" to Manual Scan settings~~** [OK] Complete (Sprint 26)
-
-**~~F45. Background scan CSV to Excel export~~** [OK] Complete (Sprint 26)
-
-**~~F36. Settings: Add General tab for app-wide settings~~** [OK] Complete (Sprint 26)
-
 **F46. Default rule set creation (~6-8h) Priority 74**
 - Phase: Core Feature
 - Platform: All
 - Create a default set of rules including all top-level domain rules and all Entire Domain rules
-
-**~~F47. Email provider domain warning on rule creation~~** [OK] Complete (Sprint 26)
 
 **F48. Scan History enhancements - multi-account, filters, totals (Issue #212) (~6-8h) Priority 78**
 - Phase: Core Feature
@@ -177,16 +138,10 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Combine all accounts, account filters, totals with tooltips, retention days in title
 - Follow-up to F7 Multi-Account Scanning
 
-**~~F7. Multi-Account Scanning~~** [OK] Complete (Sprint 26)
-
-**~~F49. Remove "Scan All Accounts" button, add account selection to Scan History (Issue #219) (~2-3h)~~** [OK] Complete (Sprint 28)
-
 **F50. Make all page text selectable and copyable to clipboard (Issue #220) (~4-6h) Priority 82**
 - Phase: UX Improvement
 - Platform: All
 - Sprint 27 retrospective feedback: extend existing selectable text pattern to all screens
-
-**~~F51. Background settings - move Scan Mode above Default Folders (Issue #221) (~0.5h)~~** [OK] Complete (Sprint 28)
 
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance
@@ -225,11 +180,6 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Phase: Android Google Play Store Readiness
 - Platform: Android
 - Validation sprint needed to verify Android app still works
-
-**~~F11. Desktop App E2E Testing with civyk-winwright (~8-10h)~~** [OK] Complete (Sprint 27)
-- Phase: Quality and Testing
-- Platform: Windows Desktop
-- [Detail](#f11-desktop-app-e2e-testing-with-civyk-winwright)
 
 **F4. Background Scanning - Android (~14-16h) Priority HOLD**
 - Phase: Android Google Play Store Readiness
@@ -322,50 +272,6 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 ## Feature and Bug Details
 
 This section contains detailed specifications for incomplete items only. Completed features have their details in sprint documents and CHANGELOG.md.
-
-### B1: MSIX Sandbox Crash at Launch
-
-**Status**: New (Microsoft Store certification failure, March 30 2026)
-**Estimated Effort**: ~10h
-**Phase**: Windows Store Readiness (BLOCKER)
-**Platform**: Windows Desktop
-**Issue**: #218
-**Target**: Sprint 28
-
-**Problem**: App crashes at launch when installed from MSIX package (Microsoft Store). Error: `File system error (-2015295536)` / 0x87E107D0. Certification testing on Surface Laptop 5 and Dell Inspiron 13-5379, OS build 26200.8037.
-
-**Root Causes (3 issues)**:
-
-1. **sqflite_common_ffi FFI initialization** (PRIMARY, ~4h)
-   - `sqfliteFfiInit()` in `main.dart:36` loads sqlite3.dll via Dart FFI
-   - Inside MSIX sandbox, DLL resolution fails or tries to write `.dart_tool/` to read-only install dir
-   - Known issue: tekartik/sqflite#945, YehudaKremer/msix#189, YehudaKremer/msix#76
-   - Fix options:
-     - **Option A** (Preferred): Replace `sqflite_common_ffi` with `sqlite3` v3.x direct usage (already transitive dep, uses build hooks for DLL bundling)
-     - **Option B**: Configure explicit DLL path in `sqfliteFfiInit()`
-     - **Option C**: Add `sqlite3_flutter_libs` dependency
-
-2. **Hardcoded `Platform.environment['APPDATA']` paths** (SECONDARY, ~2h)
-   - MSIX virtualizes `%APPDATA%` to `...\Packages\{PackageFamilyName}\LocalCache\Roaming\`
-   - Raw `Platform.environment['APPDATA']` may not match `path_provider` resolved paths
-   - Affected files (6 occurrences):
-     - `lib/main.dart:49` (background scan log)
-     - `lib/core/services/background_scan_windows_worker.dart:30,279` (log + Excel export)
-     - `lib/core/services/app_identity_migration.dart:29,35` (legacy migration)
-     - `lib/core/services/dev_environment_seeder.dart:28` (dev seeding)
-   - Fix: Replace all with `AppPaths` methods using `path_provider`
-
-3. **Platform.resolvedExecutable in MSIX** (TERTIARY, ~1h)
-   - Returns MSIX package path (read-only, changes on updates)
-   - Task Scheduler registration at `windows_task_scheduler_service.dart:259,369` may fail
-   - Fix: Detect MSIX context, skip/adapt Task Scheduler registration
-
-**Testing** (~2h):
-- Build MSIX locally: `dart run msix:create`
-- Install as non-admin user
-- Verify launch, database, rules, scanning, export
-
-**Current deps**: `sqflite: ^2.3.0`, `sqflite_common_ffi: ^2.3.0`, `sqlite3: 3.1.4` (transitive), `msix: ^3.16.8`
 
 ### Folder Selectors: Two-Level Listing (F37)
 
@@ -466,37 +372,6 @@ Provider defaults:
 
 ---
 
-### F11: Desktop App E2E Testing with civyk-winwright
-
-**Status**: In Progress (Sprint 27)
-**Estimated Effort**: ~8-10h
-**Phase**: Quality and Testing
-**Platform**: Windows Desktop
-
-**Overview**: Set up automated desktop app E2E testing using civyk-winwright MCP server, which provides Windows UI Automation (UIA3/MSAA) tools for native desktop app interaction. Playwright cannot directly test Flutter Desktop apps (Skia rendering, not browser-based), so civyk-winwright bridges this gap.
-
-**Approach**:
-- **civyk-winwright**: MCP server with ~59 tools for desktop automation (UIA3), browser CDP, system tools, and script recording/replay
-- **Accessibility tree**: Flutter Windows exposes MSAA accessibility; civyk-winwright uses UIA3 which can bridge to MSAA
-- **Investigation first**: Evaluate accessibility tree richness before committing to full test scripting
-
-**Key Features**:
-- Install and configure civyk-winwright MCP server
-- Evaluate Flutter app accessibility tree for automation feasibility
-- Exploratory testing of all Windows Desktop screens via MCP tools
-- Document bugs found, script repeatable tests via record/replay
-
-**Dependencies**: Core UI features complete (Sprints 12-17), civyk-winwright v2.0.0
-
-**Acceptance Criteria**:
-- [ ] civyk-winwright installed and accessible as MCP server in Claude Code
-- [ ] Accessibility tree evaluated and findings documented
-- [ ] Exploratory testing covers all major screens
-- [ ] Bugs found filed as GitHub issues
-- [ ] TESTING_STRATEGY.md and ARCHITECTURE.md updated with E2E testing approach
-
----
-
 ### F4: Background Scanning - Android
 
 **Status**: HOLD (Android Google Play Store Readiness)
@@ -560,70 +435,6 @@ Provider defaults:
 - [ ] Backup DB before changes
 - [ ] Report: patterns converted, duplicates removed, unchanged patterns
 - [ ] All tests pass after cleanup
-
----
-
-### Windows Store Readiness (Complete - Sprint 22)
-
-**Status**: [OK] Complete (Sprint 22)
-**Estimated Effort**: ~8-12h (research + gap analysis; implementation in separate backlog items)
-**Phase**: Windows Store Readiness
-**Platform**: Windows Desktop
-
-**Overview**: Research all requirements for publishing on the Microsoft Store (Windows Store), perform a deep analysis of the current codebase to identify gaps, and create actionable backlog items to bridge each gap. This includes creating or updating ADRs for architectural decisions required for store compliance.
-
-**Phase 1: Requirements Research (~3-4h)**
-- Microsoft Store app submission requirements (2026)
-- MSIX packaging requirements and signing
-- Store listing requirements (screenshots, descriptions, privacy policy)
-- Content policy and app certification requirements
-- Age ratings and content declarations
-- Accessibility requirements
-- Privacy and data handling declarations
-- Update and versioning requirements
-- Testing and certification process
-
-**Phase 2: Codebase Gap Analysis (~3-4h)**
-- Deep analysis of current app against each store requirement
-- Review existing MSIX config in pubspec.yaml
-- Review app identity, signing, and packaging
-- Review privacy policy status (ADR-0030)
-- Review data handling declarations
-- Review accessibility compliance
-- Review app capabilities and permissions
-- Identify all gaps with severity (blocking vs nice-to-have)
-
-**Phase 3: Gap Summary and Review (~1-2h)**
-- Present findings to user with categorized gaps
-- Discuss prioritization and approach for each gap
-- Create/update ADRs for architectural decisions needed
-
-**Phase 4: Backlog Item Creation (~1-2h)**
-- Create individual backlog items for each gap
-- Estimate effort per item
-- Identify dependencies between items
-- Propose implementation order
-
-**Acceptance Criteria**:
-- [ ] All Microsoft Store requirements documented
-- [ ] Codebase gap analysis complete with severity ratings
-- [ ] Findings reviewed with user
-- [ ] ADRs created or updated for store-related architectural decisions
-- [ ] Individual backlog items created for each gap
-- [ ] Implementation order and dependencies documented
-
-**Note**: This is similar to the existing Google Play Store Readiness section (HOLD items H6-H17) but for the Microsoft Store. Some requirements overlap (privacy policy, data deletion, icons/branding).
-
----
-
-### ~~WS-B4: Privacy Policy~~ [OK] Complete (Sprint 24)
-
-### ~~WS: Implementation Order and Dependencies~~ [OK] Complete (Sprint 24)
-
-All Windows Store readiness items completed. App submitted to Microsoft Store for certification (Sprint 24, 2026-03-21).
-```
-
-**Parallel tracks**: #17, #18, #21 can be done in parallel. #19 and #20 can be done in parallel after their dependencies.
 
 ---
 

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -143,6 +143,13 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Platform: All
 - Sprint 27 retrospective feedback: extend existing selectable text pattern to all screens
 
+**F52. Multi-variant side-by-side install across all stores (~16-24h) Priority 90**
+- Phase: Build and Release Infrastructure
+- Platform: All (Windows, Android, iOS)
+- Extend ADR-0035 dev/prod separation to all 9 build variants (3 stores × 3 channels: dev, production, store)
+- All variants must run simultaneously without rebuild on same machine/device
+- [Detail](#f52-multi-variant-side-by-side-install)
+
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance
 - Platform: All
@@ -369,6 +376,121 @@ Provider defaults:
 - [ ] Pattern preview shows match results against sample data
 - [ ] Changes saved to database
 - [ ] Rule name updated if source_domain changes
+
+---
+
+### F52: Multi-Variant Side-by-Side Install
+
+**Status**: New (April 8, 2026)
+**Estimated Effort**: ~16-24h (phased per platform)
+**Phase**: Build and Release Infrastructure
+**Platform**: All (Windows, Android, iOS)
+
+**Overview**: Extend the existing dev/prod separation (ADR-0035, Windows only) to support all 9 build variants -- 3 channels (dev, production, store) across 3 platforms (Windows, Android, iOS) -- running simultaneously on the same machine/device without rebuilds.
+
+**The 9 Variants**:
+
+| Platform | Dev (feature/develop) | Production (main) | Store (downloaded) |
+|----------|----------------------|-------------------|--------------------|
+| Windows | [OK] Built today | [OK] Built today | Microsoft Store install |
+| Android | TBD | TBD | Google Play install |
+| iOS | TBD | TBD | App Store install |
+
+**Current State**:
+- **Windows dev/prod**: ADR-0035 implemented in Sprint 19. Same .exe path, but different `secrets.*.json` builds use different data dirs (`MyEmailSpamFilter` vs `MyEmailSpamFilter_Dev`), task names, and mutexes. Whichever was built last is what runs.
+- **Windows store**: MSIX submitted to Microsoft Store (Sprint 28). Installs to `Packages\{PackageFamilyName}\` -- separate from dev/prod data dirs.
+- **Android**: Single applicationId (`com.example.my_email_spam_filter`). No flavors configured.
+- **iOS**: Not yet built.
+
+**Problem**: A user/developer needs to be able to run any combination of these 9 variants simultaneously to:
+- Compare dev vs prod behavior on same data
+- Test store version against local builds without uninstalling
+- Reproduce store-only bugs while a fix is in dev
+- Demonstrate prod features while continuing dev work
+
+The Windows dev/prod current implementation requires a rebuild to switch -- only one is "current" at a time.
+
+**Industry Best Practices**:
+
+**Android (Build Flavors)** -- See [Android docs](https://developer.android.com/build/build-variants):
+- Use `productFlavors` in `build.gradle.kts` with distinct `applicationIdSuffix` per flavor
+- Example: `com.example.app` (store), `com.example.app.prod` (sideloaded prod), `com.example.app.dev` (dev)
+- Each variant gets its own data directory, app icon, and Launcher entry
+- Side-by-side install works automatically on the same device
+- Use Manifest Placeholders for distinct app names (e.g., "SpamFilter", "SpamFilter PROD", "SpamFilter DEV")
+
+**iOS (Bundle ID + Targets/Configurations)** -- See [Xcode multi-config](https://medium.com/@danielgalasko/run-multiple-versions-of-your-app-on-the-same-device-using-xcode-configurations-1fd3a220c608):
+- iOS identifies apps by bundle identifier; cannot have two apps with the same ID
+- Create distinct bundle IDs per variant: `com.example.spamfilter`, `com.example.spamfilter.prod`, `com.example.spamfilter.dev`
+- Use Xcode build configurations or separate targets to switch bundle ID at build time
+- Each variant becomes a distinct app on the device with its own data, icon, and TestFlight stream
+- TestFlight typically uses a `.test` or `.beta` suffix to avoid colliding with App Store releases
+
+**Windows (MSIX Package Family + Distinct .exe Names)**:
+- MSIX uses `PackageFamilyName` for identity. Different `Identity Name` values produce distinct sandboxed installs.
+- For non-MSIX (sideloaded) builds, distinct .exe filenames + distinct install directories enable coexistence
+- Currently: `MyEmailSpamFilter.exe` is the same filename for dev and prod (only data dirs differ)
+- Recommendation: build to environment-specific subdirs (`Release-dev/`, `Release-prod/`) and use environment-specific .exe names (`MyEmailSpamFilter.exe`, `MyEmailSpamFilter-Dev.exe`)
+
+**Cross-Platform Pattern**:
+1. **Single source tree, build-time variants**: Use Flutter's `--dart-define` + `flutter run --flavor` for entry points
+2. **Distinct identifiers per variant**: applicationId/bundle ID/package family
+3. **Distinct visual markers**: app name, icon overlay (e.g., yellow stripe for dev, red for staging)
+4. **Distinct data isolation**: separate data dirs (already done for Windows; automatic for Android/iOS via OS)
+5. **Build matrix in CI**: each push to `main` builds prod variants, each push to `develop` builds dev variants
+
+**Key Decisions Needed (during sprint planning)**:
+1. **Naming convention**: `SpamFilter` (store) / `SpamFilter Pro` (sideloaded prod) / `SpamFilter Dev` (dev)? Or use suffixes?
+2. **Build artifact location**: Should dev and prod Windows builds output to separate dirs to enable coexistence without rebuild?
+3. **Icon variants**: Acceptable to ship 3 icon designs (or icon overlays generated at build time)?
+4. **Store identifier strategy**: Reserve all bundle IDs in advance (App Store Connect, Google Play Console, Microsoft Partner Center)?
+
+**Implementation Phases**:
+
+**Phase 1: Windows distinct .exe + distinct dirs (~4-6h)**
+- Update `build-windows.ps1` to output to `build/windows/x64/runner/Release-{env}/`
+- Rename .exe to `MyEmailSpamFilter.exe` (prod) and `MyEmailSpamFilter-Dev.exe` (dev) at build time
+- Verify Microsoft Store MSIX is unaffected (it installs separately)
+- Update launch scripts and docs to reference env-specific paths
+- Test: prod and dev builds present simultaneously, both runnable
+
+**Phase 2: Android flavors (~6-8h)**
+- Configure `productFlavors` in `mobile-app/android/app/build.gradle.kts`
+- Define `dev`, `prod`, `store` flavors with distinct `applicationIdSuffix`
+- Add Manifest Placeholder for app name
+- Generate distinct icons per flavor (or use icon overlay)
+- Update build scripts (`build-with-secrets.ps1`) to take a flavor parameter
+- Test: install all 3 variants on emulator side-by-side
+- Note: Cannot fully test "store" flavor until app is in Google Play (use `prod` flavor as proxy with different applicationId)
+
+**Phase 3: iOS bundle IDs (~6-10h, requires macOS)**
+- Configure Xcode build configurations or targets for `dev`, `prod`, `store`
+- Set distinct bundle IDs per configuration
+- Configure provisioning profiles for each variant
+- Update CI to build correct variant per branch
+- Note: Requires Apple Developer Program account and reserved bundle IDs
+- HOLD until iOS development begins
+
+**Acceptance Criteria**:
+- [ ] Windows: dev, prod, and store builds all installable and runnable simultaneously
+- [ ] Android: dev, prod, and store flavors all installable and runnable simultaneously on emulator
+- [ ] iOS: dev, prod, and store configurations defined (full validation deferred to iOS dev)
+- [ ] All 9 variants have distinct data directories (no cross-contamination)
+- [ ] All 9 variants have visual markers (different name and/or icon)
+- [ ] Build scripts updated to support variant selection
+- [ ] Documentation updated: ADR (extend ADR-0035 or create new ADR), CLAUDE.md, build script READMEs
+- [ ] No regression in existing dev/prod Windows separation
+- [ ] CI builds correct variant per branch (main = prod+store, develop = dev)
+
+**Dependencies**:
+- iOS phase blocked until iOS development begins
+- Android store flavor blocked until app is published to Google Play
+- Windows store flavor already in place (MSIX from Sprint 28)
+
+**Notes**:
+- Phase 1 (Windows) is the only phase that can be done now without external dependencies
+- Phases 2 and 3 should be combined with broader Android/iOS work
+- Consider whether "store" flavor is really needed as a separate build, or if the actual store-downloaded app suffices
 
 ---
 

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -157,6 +157,14 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Target: Sprint 30
 - Quick win, similar to other TLD blocks
 
+**F54. Add icon to Select Account screen icon row (~1-2h) Priority 64**
+- Phase: UX Improvement
+- Platform: All
+- Current icon row: View Scan History (history), Settings (gear), Exit Application
+- Add a new icon+tooltip to the AppBar actions row
+- Needs: icon choice, tooltip/label, navigation target
+- Design decision: what action should this trigger? (account management, add account, etc.)
+
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance
 - Platform: All

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -165,6 +165,21 @@ All incomplete items in relative priority order. Priority in increments of 10; i
 - Needs: icon choice, tooltip/label, navigation target
 - Design decision: what action should this trigger? (account management, add account, etc.)
 
+**F55. Screen navigation consistency - linear flow + push/pop icons (~4-6h) Priority 66**
+- Phase: UX Improvement
+- Platform: All
+- Two navigation models: linear scan flow (back returns up chain) and icon navigation (push/pop returns to origin)
+- Linear flow: Select Account -> Manual Scan -> Live Scan Results; back buttons return one step up
+- Icon navigation: Settings, Scan History, Select Account icons push onto stack; back pops to origin
+- Current issues:
+  - Results back button uses pushReplacement instead of pop (breaks stack)
+  - "Back to Accounts" button on Results skips Manual Scan via popUntil
+  - Results -> Manual Scan auto-navigation on scan complete should be push (not pushReplacement)
+- Consider: keep "Back to Accounts" as convenience shortcut or remove for consistency?
+- Consider: "Scan Again" pushReplacement is correct (avoids stack bloat on repeated scans)
+- Consider: does the user need a Select Account icon on Manual Scan and Results screens?
+- Related: F54 (add icon to Select Account screen)
+
 **F6. Provider-Specific Optimizations (~10-12h) Priority 100**
 - Phase: Performance
 - Platform: All

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,7 +28,7 @@
 
 Cross-platform email spam filtering application built with 100% Flutter/Dart for all platforms (Windows, macOS, Linux, Android, iOS). The app uses IMAP/OAuth protocols to support multiple email providers (AOL, Gmail, Yahoo, iCloud) with a single codebase, SQLite database for rules and scan history, and portable YAML rule export for version control.
 
-**Current Status**: Sprint 17 complete (Feb 2026) - 977 tests passing, 28 skipped, 0 failures.
+**Current Status**: See [CHANGELOG.md](../CHANGELOG.md) for current version, sprint, and test count.
 
 ---
 
@@ -136,7 +136,7 @@ Business logic and domain services.
 **Purpose**: Compiles and caches regex patterns for efficient matching
 
 **Features**:
-- `HashMap<String, RegExp>` cache with ~100x speedup (2.1ms -> 0.18ms)
+- `HashMap<String, RegExp>` cache (see [PERFORMANCE_BENCHMARKS.md](PERFORMANCE_BENCHMARKS.md) for speedup metrics)
 - Case-insensitive matching
 - Python-style inline flag stripping (`(?i)`, `(?m)`, `(?s)`, `(?x)`)
 - Error tracking for invalid patterns (graceful fallback to never-matching regex)
@@ -159,7 +159,7 @@ Business logic and domain services.
 4. Initialize scan result persistence (database)
 5. For each folder: fetch messages, evaluate against rules, take actions (batch operations)
 6. Persist individual email actions to database
-7. Update UI progress (throttled: every 10 emails OR every 2 seconds)
+7. Update UI progress (throttled per [ADR-0022](adr/0022-throttled-ui-progress-updates.md))
 8. Finalize scan results
 
 #### RuleConflictDetector
@@ -221,7 +221,7 @@ Note: The legacy `EmailProvider` abstract class still exists but is only used fo
 |---------|----------|------|---------|-------------|
 | **GmailApiAdapter** | Gmail REST API | OAuth 2.0 | `PlatformRegistry.getPlatform('gmail')` | Uses `googleapis` package, batch operations via `BatchOperationsMixin`, Gmail labels |
 | **GenericIMAPAdapter** | IMAP | Username/password | `.aol()`, `.yahoo()`, `.icloud()`, `.custom()` | Uses `enough_mail` package, UID-based operations (not sequence IDs), reconnects every 50 ops |
-| **MockEmailProvider** | None (in-memory) | None | `PlatformRegistry.getPlatform('demo')` | 55 synthetic emails across 5 categories (ADR-0020) |
+| **MockEmailProvider** | None (in-memory) | None | `PlatformRegistry.getPlatform('demo')` | Synthetic test emails (see [ADR-0020](adr/0020-demo-mode-synthetic-emails.md) for details) |
 
 **PlatformRegistry** (Factory Pattern):
 ```dart
@@ -282,7 +282,7 @@ Uses IMAP UID sequence sets to reduce round-trips from 3N to ~3 batch operations
 
 #### Schema (ADR-0010)
 
-SQLite database with the following tables:
+SQLite database schema. See [ADR-0010](adr/0010-normalized-database-schema.md) for the authoritative table count and schema definition. Key tables:
 
 | Table | Purpose | Key Fields |
 |-------|---------|------------|
@@ -369,7 +369,7 @@ Reactive state using Provider pattern (ADR-0009).
 
 **Methods**:
 - `startScan(totalEmails, scanType, foldersScanned)`: Initialize scan with persistence
-- `updateProgress(email, message)`: Report progress (throttled: every 10 emails OR 2 seconds, ADR-0022)
+- `updateProgress(email, message)`: Report progress (throttled per [ADR-0022](adr/0022-throttled-ui-progress-updates.md))
 - `completeScan()`: Finalize results and persist
 - `setCurrentFolder(folderName)`: Track folder being scanned
 - `initializePersistence()`: Setup database stores for scan history
@@ -474,7 +474,7 @@ RuleEvaluator.evaluate(EmailMessage)
 
 ## UI Layer (`lib/ui/`)
 
-### Screens (19 screens)
+### Screens
 
 | Screen | Purpose |
 |--------|---------|
@@ -526,11 +526,11 @@ mobile-app/
 |   |   |- auth/               # Auth adapters (GoogleAuthService, SecureTokenStore)
 |   |   |- gmail/              # Gmail API client wrapper
 |   |- ui/                      # Flutter screens and widgets
-|       |- screens/            # 19 full-screen pages
+|       |- screens/            # Full-screen pages
 |       |- widgets/            # Reusable components
 |       |- theme/              # AppTheme (Material Design)
 |       |- utils/              # Accessibility helpers
-|- test/                        # Tests (977 passing, 28 skipped)
+|- test/                        # Tests (run `flutter test` for current count)
 |   |- unit/                   # Unit tests (models, services)
 |   |- integration/            # Integration tests (adapters, workflows)
 |   |- adapters/               # Adapter-specific tests
@@ -547,16 +547,17 @@ mobile-app/
 
 | Layer | Technology | Purpose |
 |-------|------------|---------|
-| **UI Framework** | Flutter 3.x | Cross-platform UI (5 platforms) |
-| **Language** | Dart 3.x | Application logic |
-| **State Management** | Provider (v6.1.0) | Reactive state via ChangeNotifier |
-| **Local Storage** | SQLite (sqflite/sqflite_ffi) | Persistent data (8 tables, 10+ indexes) |
+| **UI Framework** | Flutter / Dart | Cross-platform UI and application logic |
+| **State Management** | Provider | Reactive state via ChangeNotifier ([ADR-0009](adr/0009-provider-pattern-state-management.md)) |
+| **Local Storage** | SQLite (sqflite/sqflite_ffi) | Persistent data ([ADR-0010](adr/0010-normalized-database-schema.md)) |
 | **Secure Storage** | flutter_secure_storage | Credentials, tokens (OS-native keystores) |
 | **Networking** | http, googleapis | REST APIs (Gmail) |
 | **Email** | enough_mail | IMAP protocol (AOL, Yahoo, iCloud) |
 | **OAuth** | google_sign_in (mobile), flutter_appauth (desktop) | Gmail authentication |
-| **System Tray** | system_tray (v2.0.3), window_manager (v0.3.7) | Windows desktop integration |
-| **Logging** | logger (v2.0.0) | Keyword-based logging via AppLogger |
+| **System Tray** | system_tray, window_manager | Windows desktop integration |
+| **Logging** | logger | Keyword-based logging via AppLogger |
+
+**Package versions**: See `mobile-app/pubspec.yaml` for current dependency versions.
 
 ---
 
@@ -637,7 +638,7 @@ mobile-app/
 
 ## Testing Strategy
 
-**Current State**: 977 tests passing, 28 skipped, 0 failures (Sprint 17)
+**Current State**: Run `flutter test` for current count. See [CHANGELOG.md](../CHANGELOG.md) for test history.
 
 ### Unit Tests
 - Models: Immutability, copyWith, serialization
@@ -670,25 +671,29 @@ mobile-app/
 
 ### Pattern Caching (ADR-0023)
 - `PatternCompiler` uses `HashMap<String, RegExp>` cache
-- ~100x speedup (2.1ms -> 0.18ms per pattern)
+- See [PERFORMANCE_BENCHMARKS.md](PERFORMANCE_BENCHMARKS.md) for detailed speedup metrics
 - Cache hit/miss statistics for monitoring
 
 ### Throttled UI Updates (ADR-0022)
-- Dual-threshold: notify every 10 emails OR every 2 seconds
+- Dual-threshold notify (see [ADR-0022](adr/0022-throttled-ui-progress-updates.md) for thresholds)
 - Separate throttle for result recording
 - Reset counters on scan start to prevent accumulation
 
 ### Batch Operations
-- `BatchOperationsMixin` reduces IMAP round-trips from 3N to ~3 batch operations
+- `BatchOperationsMixin` reduces IMAP round-trips via batch operations
 - Uses IMAP UID sequence sets for bulk delete/move/mark-as-read
 
 ### Asynchronous Operations
 - All I/O operations are async (file, network, database)
-- Folder-by-folder progressive scanning with 2-second UI refresh interval
+- Folder-by-folder progressive scanning with throttled UI refresh
 
 ---
 
 ## Future Architecture Enhancements
+
+### Browser / Flutter Web (Excluded)
+
+A browser target has been evaluated and excluded. The app's IMAP-based email providers (AOL, Yahoo, iCloud, custom IMAP) require raw TCP socket connections, which browsers block via the Same-Origin Policy. The only viable workaround -- a server-side IMAP proxy (the approach used by browser-based email clients such as Outlook Web) -- would route user credentials and email content through a backend server, directly contradicting the local-only, zero-telemetry privacy architecture ([ADR-0030](adr/0030-privacy-and-data-governance-strategy.md)). Chromebook users are served by the existing Android (Play Store) and Linux (Crostini) targets. See [ARSD.md](ARSD.md) Section A1 for full rationale.
 
 ### Rule Sync (Future)
 - Cloud sync for rules across devices
@@ -698,70 +703,19 @@ mobile-app/
 - Extensible rule actions (custom scripts)
 - Third-party email provider plugins
 
-### Google Play Store Readiness (ADRs 0026-0034)
+### Google Play Store Readiness
 
-Product readiness decisions documented as ADRs. See `docs/adr/` for details.
+Product readiness decisions documented as ADRs (0026-0034). See [ADR Index](adr/README.md) for current status of each.
 
-**Accepted**:
-- ADR-0026: Application Identity -- Domain `myemailspamfilter.com`, App ID `com.myemailspamfilter`, App Name `MyEmailSpamFilter`
-- ADR-0029: Gmail API Scope Strategy -- Phased approach: unverified OAuth for alpha/beta, app passwords for general users, CASA deferred until 2,500+ users or $5K/yr revenue
-- ADR-0030: Privacy and Data Governance -- Zero telemetry, host privacy policy on `myemailspamfilter.com` via GitHub Pages, indefinite local storage, in-app + web account deletion
-- ADR-0034: Gmail Access Method -- Dual path: Gmail REST API (OAuth) for alpha/beta, Gmail IMAP (app passwords) for general users
+### Gmail Authentication Strategy
 
-**Proposed** (decisions pending):
-- ADR-0027: Android Release Signing Strategy
-- ADR-0028: Android Permission Strategy
-- ADR-0031: App Icon and Visual Identity
-- ADR-0032: User Data Deletion Strategy
-- ADR-0033: Analytics and Crash Reporting Strategy
-
-### Gmail Authentication Strategy (ADR-0029, ADR-0034)
-
-The app supports two Gmail access paths, matching investment to viability:
-
-| Phase | Method | Users | Scope | Verification |
-|-------|--------|-------|-------|--------------|
-| 1 (Alpha/Beta) | Gmail REST API + OAuth | Up to 100 testers | `gmail.modify` | None (Testing mode) |
-| 2 (General) | Gmail IMAP + App Passwords | Unlimited | N/A (no OAuth) | None |
-| 3 (Future) | Gmail REST API + Verified OAuth | Unlimited | `gmail.modify` | CASA audit required |
-
-**CASA trigger**: Pursue verification when app has 2,500+ active Gmail IMAP users at $3/yr or yearly revenue exceeds $5,000.
+The app supports dual Gmail access paths. See [ADR-0029](adr/0029-gmail-api-scope-and-verification-strategy.md) and [ADR-0034](adr/0034-gmail-access-method-for-production.md) for the phased strategy and CASA trigger thresholds.
 
 ---
 
 ## Architecture Decision Records
 
-All architectural decisions are documented as ADRs in `docs/adr/`. Currently 29 accepted and 5 proposed.
-
-**Accepted ADRs** (0001-0025):
-
-| ADR | Title | Key Decision |
-|-----|-------|--------------|
-| 0001 | Flutter/Dart Single Codebase | 100% Flutter for all 5 platforms |
-| 0002 | Adapter Pattern for Email Providers | SpamFilterPlatform interface + PlatformRegistry factory |
-| 0003 | Regex-Only Pattern Matching | All patterns compiled as Dart RegExp, case-insensitive |
-| 0004 | Dual-Write Storage (SQLite + YAML) | SQLite authoritative, YAML exported for version control |
-| 0005 | Safe Senders Evaluated Before Rules | Whitelist checked first, then rules in execution order |
-| 0006 | Four Progressive Scan Modes | readonly/testLimit/testAll/fullScan with enforcement flags |
-| 0007 | Move-to-Trash, Not Permanent Delete | Delete = trash (recoverable) |
-| 0008 | Platform-Native Secure Storage | flutter_secure_storage wraps OS keystores |
-| 0009 | Provider Pattern for State Management | ChangeNotifier-based providers |
-| 0010 | Normalized Database Schema | 8 tables, JSON arrays, text enums, 10+ indexes |
-| 0011 | Desktop OAuth via Loopback + PKCE | Desktop: loopback server; Mobile: native SDKs |
-| 0012 | AppPaths Platform Storage Abstraction | Platform-agnostic path resolution |
-| 0013 | Per-Account Settings with Inheritance | Account -> App -> Hardcoded three-tier fallback |
-| 0014 | Windows Background Scanning | Task Scheduler with PowerShell scripts |
-| 0015 | GitFlow Branching Strategy | main <- develop <- feature branches |
-| 0016 | Sprint-Based Development with Model Tiering | Haiku/Sonnet/Opus complexity scoring |
-| 0017 | PowerShell as Primary Build Automation | All build scripts are .ps1 |
-| 0018 | Windows Toast Notifications | PowerShell-generated WinRT notifications |
-| 0019 | Windows System Tray Integration | system_tray + window_manager |
-| 0020 | Demo Mode with Synthetic Emails | MockEmailProvider with 55 test emails |
-| 0021 | YAML-to-Database One-Time Migration | Transaction-wrapped idempotent import |
-| 0022 | Throttled UI Progress Updates | Every 10 emails OR every 2 seconds |
-| 0023 | In-Memory Pattern Caching | HashMap cache, ~100x speedup |
-| 0024 | Canonical Folder Mapping | Provider-specific junk folder names |
-| 0025 | CHANGELOG Updated Per Commit | Update in same commit as code changes |
+All architectural decisions are documented as ADRs in `docs/adr/`. See [ADR Index](adr/README.md) for the complete list with current status.
 
 ---
 
@@ -771,7 +725,7 @@ All architectural decisions are documented as ADRs in `docs/adr/`. Currently 29 
 **Update**: February 24, 2026 (ADR-0026/0029/0030/0034 accepted, Gmail auth strategy documented)
 **Related Documents**:
 - `docs/RULE_FORMAT.md` - YAML rule specification
-- `docs/adr/` - Architecture Decision Records (ADR-0001 through ADR-0034)
+- `docs/adr/README.md` - Architecture Decision Records index
 - `CLAUDE.md` - Primary development guide
 - `docs/SPRINT_PLANNING.md` - Development methodology
 - `CHANGELOG.md` - Project change history

--- a/docs/ARSD.md
+++ b/docs/ARSD.md
@@ -1,0 +1,830 @@
+# Architecture Requirements Specification & Design (ARS&D)
+
+## MyEmailSpamFilter -- Cross-Platform Email Spam Filtering Application
+
+---
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARS&D-2026-001 |
+| **Version** | 1.0 (Draft) |
+| **Date** | 2026-04-03 |
+| **Authors** | Harold Kimmey (Product Owner), Claude Code (AI Development Partner) |
+| **Status** | Draft |
+| **TOGAF Alignment** | Tailored per ADR-2026-04-003 (Combined ADD + ARS with Structured Separation) |
+| **Governing ADRs** | See [ADR Index](adr/README.md) for current count and status |
+
+---
+
+## Executive Summary
+
+MyEmailSpamFilter is a cross-platform email spam filtering application built with 100% Flutter/Dart targeting desktop (Windows, macOS, Linux), mobile (Android phone/tablet, iOS phone/tablet), and Chromebook (via Android or Linux targets). The application connects to multiple email providers (Gmail, AOL, Yahoo, iCloud, custom IMAP) through a provider-agnostic adapter architecture, evaluates emails against user-defined regex rules, and takes configurable actions (move to trash, move to folder) with safety-first defaults.
+
+The architecture is governed by [Architecture Decision Records](adr/README.md) that establish core principles: single codebase across all platforms, provider agnosticism via the adapter pattern, local-first privacy with zero telemetry, safety-by-default scan modes, and platform-native integration for credentials, notifications, and background scanning.
+
+**Current State**: See [CHANGELOG.md](../CHANGELOG.md) for current version, sprint, and test status.
+
+**Target State**: Full distribution across Microsoft Store (Windows), Google Play (Android), and Apple App Store (iOS). Responsive design supporting phone, tablet, and desktop form factors. All platforms validated with platform-native integrations where applicable.
+
+**Browser Exclusion**: A browser (Flutter Web) target has been evaluated and excluded. The app relies on IMAP protocol (raw TCP sockets) for AOL, Yahoo, iCloud, and custom IMAP providers, which is incompatible with the browser security model (Same-Origin Policy blocks TCP connections). A browser version would require a server-side IMAP proxy to relay connections, which directly contradicts the app's local-only, zero-telemetry privacy architecture ([ADR-0030](adr/0030-privacy-and-data-governance-strategy.md)). Chromebook users are served by the existing Android (Play Store) and Linux (Crostini) targets.
+
+---
+
+## Stakeholder Map & RACI
+
+| Stakeholder | Role | R | A | C | I |
+|-------------|------|---|---|---|---|
+| Harold Kimmey | Product Owner, Lead Developer | Architecture, Sprint Planning, Release | All decisions | -- | -- |
+| Claude Code (Opus/Sonnet/Haiku) | AI Development Partner | Implementation, Testing, Documentation | -- | Architecture, Sprint Scope | -- |
+| End Users | Email account holders | -- | -- | Feature requests, bug reports | Release notes, privacy policy |
+| Microsoft Store Review | Platform gatekeeper | -- | -- | -- | MSIX certification (ADR-0036) |
+| Google Play Review | Platform gatekeeper | -- | -- | -- | App review, data safety (ADR-0030) |
+| Apple App Store Review | Platform gatekeeper | -- | -- | -- | App review (future) |
+| Google API Services | Gmail data policy enforcement | -- | -- | -- | OAuth scope verification (ADR-0029) |
+
+**Legend**: R = Responsible, A = Accountable, C = Consulted, I = Informed
+
+---
+
+# PART A: ARCHITECTURE DEFINITION
+
+*Qualitative -- "What does the architecture look like, and why?"*
+
+---
+
+## A1. Scope & Boundaries
+
+### In Scope
+
+- **Platforms**: Desktop (Windows, macOS, Linux), Mobile (Android phone/tablet, iOS phone/tablet), Chromebook (via Android Play Store or Linux Crostini)
+- **Email Providers**: Gmail (REST API + OAuth), AOL, Yahoo, iCloud (IMAP), custom IMAP servers, Demo mode
+- **Core Function**: Regex-based email spam filtering with configurable rules and safe sender whitelists
+- **Processing Model**: Local-only, on-device processing -- no backend server
+- **Distribution**: Microsoft Store, Google Play, Apple App Store
+
+### Out of Scope
+
+- Email client replacement (not a mail reader)
+- Server-side email processing or filtering
+- Machine learning or AI-based classification
+- Multi-user or team collaboration features
+- Email composition or sending
+- **Browser / Flutter Web target**: IMAP protocol requires raw TCP sockets, which browsers block via the Same-Origin Policy. A browser version would require a server-side IMAP proxy, contradicting the local-only privacy architecture (ADR-0030). Chromebook users are served by Android and Linux targets instead.
+
+### System Boundary
+
+The application operates as a client-side tool that authenticates with email providers, reads email metadata/content transiently, evaluates against locally stored rules, and takes actions via provider APIs. No user data leaves the device except for authentication with email providers.
+
+```mermaid
+graph TD
+    subgraph "System Boundary: MyEmailSpamFilter"
+        APP["MyEmailSpamFilter<br/>Flutter/Dart Application"]
+    end
+
+    USER["End User"] --> APP
+
+    subgraph "Email Providers (External)"
+        GMAIL["Gmail REST API"]
+        IMAP["IMAP Servers<br/>(AOL, Yahoo, iCloud)"]
+    end
+
+    subgraph "OS Services (External)"
+        CRED["Credential Stores<br/>(Keychain, Keystore,<br/>Credential Manager, libsecret)"]
+        SCHED["Task Scheduler<br/>(Windows) /<br/>WorkManager (Android)"]
+        NOTIFY["Notifications<br/>(Toast, System Tray)"]
+    end
+
+    subgraph "Distribution (External)"
+        MSSTORE["Microsoft Store"]
+        GPLAY["Google Play"]
+        APPSTORE["Apple App Store"]
+    end
+
+    APP <--> GMAIL
+    APP <--> IMAP
+    APP <--> CRED
+    APP <--> SCHED
+    APP --> NOTIFY
+    APP -.-> MSSTORE
+    APP -.-> GPLAY
+    APP -.-> APPSTORE
+```
+
+**Reference**: [ADR-0001](adr/0001-flutter-dart-single-codebase.md) (Single Codebase), [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) (Privacy)
+
+---
+
+## A2. Architecture Principles
+
+Eight governing principles distilled from the [ADR corpus](adr/README.md):
+
+| # | Principle | Description | Governing ADRs |
+|---|-----------|-------------|----------------|
+| 1 | **Single Codebase** | One Flutter/Dart codebase compiles for all target platforms | [ADR-0001](adr/0001-flutter-dart-single-codebase.md) |
+| 2 | **Provider Agnosticism** | Business logic decoupled from email providers via abstract interfaces (`SpamFilterPlatform`) | [ADR-0002](adr/0002-adapter-pattern-email-providers.md) |
+| 3 | **Local-First Privacy** | No backend server, no data transmission, no telemetry. All processing on-device. | [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) |
+| 4 | **Safety-by-Default** | Readonly scan mode as default, move-to-trash (not permanent delete), progressive scan modes | [ADR-0006](adr/0006-four-progressive-scan-modes.md), [ADR-0007](adr/0007-move-to-trash-not-permanent-delete.md) |
+| 5 | **Platform-Native Integration** | Use OS-native credential stores, notification systems, and schedulers | [ADR-0008](adr/0008-platform-native-secure-credential-storage.md), [ADR-0014](adr/0014-windows-background-scanning-task-scheduler.md), [ADR-0018](adr/0018-windows-toast-notifications-powershell.md), [ADR-0019](adr/0019-windows-system-tray-integration.md) |
+| 6 | **Database as Source of Truth** | SQLite is the authoritative store for rules, scan history, and settings. YAML is import/export only. | [ADR-0004](adr/0004-dual-write-sqlite-yaml.md), [ADR-0021](adr/0021-yaml-to-database-one-time-migration.md) |
+| 7 | **Testability** | Adapter pattern enables isolated testing. Mock provider for demo mode. 80%+ coverage target. | [ADR-0020](adr/0020-demo-mode-synthetic-emails.md) |
+| 8 | **Incremental Delivery** | Sprint-based development with AI model tiering (Haiku/Sonnet/Opus) for task complexity. | [ADR-0016](adr/0016-sprint-model-tiering-haiku-sonnet-opus.md) |
+
+---
+
+## A3. Business Architecture
+
+### Baseline (Current State)
+
+- **Windows**: Production release, Windows Store submission in progress ([ADR-0036](adr/0036-msix-signing-strategy.md))
+- **Android**: Development-ready, debug builds on emulator, Google Play submission on hold
+- **Gmail**: Dual-path access -- REST API (OAuth) + IMAP (app passwords) per [ADR-0034](adr/0034-gmail-access-method-for-production.md)
+- **IMAP Providers**: AOL, Yahoo, iCloud validated
+- **Features Delivered**: Multi-account, progressive scan modes ([ADR-0006](adr/0006-four-progressive-scan-modes.md)), background scanning (Windows), safe sender whitelist, rule management, scan history, demo mode, YAML import/export
+- See [CHANGELOG.md](../CHANGELOG.md) for current version, sprint, and test count
+
+### Target State
+
+- **8 deployment targets**: Windows desktop, macOS desktop, Linux desktop, Android phone, Android tablet, iOS phone, iOS tablet, Chromebook (via Android/Linux)
+- **3 distribution channels**: Microsoft Store, Google Play, Apple App Store
+- **Responsive design**: Adaptive layouts for phone, tablet, and desktop form factors
+- **Background scanning**: Platform-native on all supported platforms
+- **Gmail API verified**: CASA audit when threshold reached (2,500+ users or $5K/yr revenue, per ADR-0029)
+
+### Gap Analysis
+
+| Gap | Baseline | Target | Blocking ADRs | Validated |
+|-----|----------|--------|---------------|-----------|
+| macOS/Linux not validated | Architecture supports, untested | Validated and distributed | ADR-0001 | Architecture OK |
+| iOS (iPhone/iPad) not validated | Architecture supports, untested | Validated and distributed | ADR-0001 | Architecture OK |
+| Google Play submission | On hold (Gmail API verification) | Published | ADR-0029, ADR-0034 | Architecture OK |
+| Apple App Store | Not started | Published | -- (new ADR needed) | Architecture OK |
+| Android tablet layout | Desktop-optimized UI | Responsive tablet layout | -- (new ADR needed) | Architecture OK |
+| Flutter Web / Browser | Not started | **Excluded** -- IMAP incompatible with browser security model; server-side proxy contradicts local-only privacy (ADR-0030) | -- | Excluded |
+| Chromebook | Not started | Chrome OS via Android or Linux | -- | Via Play Store (Android) or Crostini (Linux) |
+| Responsive design | Desktop-optimized UI | Phone/tablet/desktop adaptive | -- (new ADR needed) | Architecture OK |
+| Account deletion UI | Not yet built | In-app + web page | ADR-0032 | Decision made |
+| Analytics framework | Included but not initialized | Removed | ADR-0033 | Decision made |
+
+### Platform Expansion Validation Notes (April 2026)
+
+**Android (phone + tablet)**: Architecture fully supports both form factors from a single APK/AAB. ADR-0027 (signing) and ADR-0028 (permissions) now Accepted. Remaining gap is responsive UI for tablet screen sizes.
+
+**iOS (iPhone + iPad)**: Flutter compiles natively to iOS. `google_sign_in` has iOS support. Keychain for credentials per ADR-0008. Build pipeline (Xcode + CocoaPods) not yet validated. New ADR needed for Apple App Store submission.
+
+**Browser (Chrome, Edge, Safari)**: **Excluded** after evaluation. Critical incompatibilities:
+- `enough_mail` (IMAP): Raw TCP sockets are blocked by browser Same-Origin Policy. IMAP providers (AOL, Yahoo, iCloud) cannot be accessed from a browser without a server-side IMAP proxy.
+- A server-side proxy (the approach used by Outlook Web and similar browser-based email clients) would require routing user credentials and email traffic through a backend server, directly contradicting the local-only, zero-telemetry privacy architecture (ADR-0030).
+- Secondary blockers: `sqflite`/`sqflite_ffi` have no web support (requires IndexedDB), and `flutter_secure_storage` has limited browser support (weaker than native keystores).
+- A Gmail-only browser version is technically feasible (Gmail REST API works over HTTPS) but would exclude all IMAP providers, offering a degraded product that does not justify the additional engineering and maintenance cost.
+
+**Chromebook**: Best path is via existing Android (Play Store) or Linux (Crostini) targets, both of which are already in the architecture. A dedicated Flutter Web target for Chromebook is not necessary and carries the same IMAP blocker as the browser target.
+
+**References**: [ADR-0026](adr/0026-application-identity-and-package-naming.md) through [ADR-0036](adr/0036-msix-signing-strategy.md)
+
+---
+
+## A4. Data Architecture
+
+### Baseline
+
+- **SQLite database** as sole source of truth (see [ADR-0010](adr/0010-normalized-database-schema.md) for schema details)
+- **Credentials**: Encrypted at rest via OS-native keystores ([ADR-0008](adr/0008-platform-native-secure-credential-storage.md))
+- **Email content**: In-memory only, never persisted ([ADR-0030](adr/0030-privacy-and-data-governance-strategy.md))
+- **YAML**: Import/export only, not authoritative ([ADR-0004](adr/0004-dual-write-sqlite-yaml.md))
+- **Settings**: Three-tier inheritance -- account -> app -> hardcoded defaults ([ADR-0013](adr/0013-per-account-settings-with-inheritance.md))
+
+### Target
+
+- Same local-only architecture (no cloud sync planned)
+- Data deletion capability (in-app + web page, per [ADR-0032](adr/0032-user-data-deletion-strategy.md))
+- Firebase Analytics dependency removed ([ADR-0033](adr/0033-analytics-and-crash-reporting-strategy.md))
+
+### Data Classification (per ADR-0030)
+
+| Data Type | Storage | Encrypted | Persisted | Shared |
+|-----------|---------|-----------|-----------|--------|
+| Email address | flutter_secure_storage | Yes | Yes | No |
+| OAuth tokens | flutter_secure_storage | Yes | Yes | No |
+| IMAP passwords | flutter_secure_storage | Yes | Yes | No |
+| Email headers/body | In-memory only | N/A | No | No |
+| Scan result metadata | SQLite | No | Yes | No |
+| Spam filter rules | SQLite + YAML export | No | Yes | No |
+| Safe sender patterns | SQLite + YAML export | No | Yes | No |
+| App/account settings | SQLite | No | Yes | No |
+
+---
+
+## A5. Application Architecture
+
+### Layered Architecture
+
+The application follows a 5-layer architecture with strict dependency direction (top to bottom):
+
+```mermaid
+graph TD
+    subgraph "Layer 1: UI"
+        UI["Screens + Widgets<br/><i>lib/ui/</i>"]
+    end
+
+    subgraph "Layer 2: State Management"
+        RSP["RuleSetProvider"]
+        ESP["EmailScanProvider"]
+    end
+
+    subgraph "Layer 3: Business Logic"
+        RE["RuleEvaluator"]
+        ES["EmailScanner"]
+        PC["PatternCompiler"]
+        RCD["RuleConflictDetector"]
+        BG["Background Services"]
+    end
+
+    subgraph "Layer 4: Adapters"
+        EA["Email Adapters<br/>(Gmail, IMAP, Mock)"]
+        AA["Auth Adapters<br/>(GoogleAuth, SecureStore)"]
+        SA["Storage Adapters<br/>(AppPaths, LocalRuleStore)"]
+    end
+
+    subgraph "Layer 5: External Systems"
+        GMAIL2["Gmail API"]
+        IMAP2["IMAP Servers"]
+        DB["SQLite Database"]
+        FS["File System"]
+        OS["OS Services"]
+    end
+
+    UI --> RSP
+    UI --> ESP
+    RSP --> RE
+    RSP --> PC
+    ESP --> ES
+    ES --> EA
+    ES --> RE
+    ES --> ESP
+    BG --> ES
+    EA --> GMAIL2
+    EA --> IMAP2
+    AA --> OS
+    SA --> FS
+    RSP --> DB
+    ESP --> DB
+```
+
+### Adapter Pattern (ADR-0002)
+
+```mermaid
+classDiagram
+    class SpamFilterPlatform {
+        <<abstract>>
+        +String platformId
+        +String displayName
+        +AuthMethod supportedAuthMethod
+        +loadCredentials(Credentials)
+        +fetchMessages(daysBack, folderNames)
+        +takeAction(message, action)
+        +moveToFolder(message, targetFolder)
+        +setDeletedRuleFolder(folderName)
+    }
+
+    class BatchOperationsMixin {
+        <<mixin>>
+        +batchDelete(messages)
+        +batchMove(messages, folder)
+        +batchMarkAsRead(messages)
+    }
+
+    class GmailApiAdapter {
+        platformId = "gmail"
+        Gmail REST API + OAuth
+    }
+
+    class GenericIMAPAdapter {
+        platformId = "aol|yahoo|icloud|imap"
+        IMAP protocol
+        +aol() factory
+        +yahoo() factory
+        +icloud() factory
+        +custom() factory
+    }
+
+    class MockEmailProvider {
+        platformId = "demo"
+        Synthetic test emails (ADR-0020)
+    }
+
+    class PlatformRegistry {
+        +getPlatform(platformId) SpamFilterPlatform
+        -_factories Map
+    }
+
+    SpamFilterPlatform <|-- GmailApiAdapter
+    SpamFilterPlatform <|-- GenericIMAPAdapter
+    SpamFilterPlatform <|-- MockEmailProvider
+    BatchOperationsMixin <|.. GmailApiAdapter
+    BatchOperationsMixin <|.. GenericIMAPAdapter
+    PlatformRegistry --> SpamFilterPlatform : creates
+```
+
+### Design Patterns in Use
+
+| Pattern | Where Used | Purpose | Reference |
+|---------|------------|---------|-----------|
+| Adapter | SpamFilterPlatform implementations | Unify email provider APIs | ADR-0002 |
+| Factory | PlatformRegistry | Provider instantiation by ID | ADR-0002 |
+| Provider/Observer | RuleSetProvider, EmailScanProvider | Reactive state management | ADR-0009 |
+| Dual-Write | RuleDatabaseStore + LocalRuleStore | SQLite primary, YAML secondary | ADR-0004 |
+| Repository | Store classes | Abstract storage layer | ADR-0010 |
+| Strategy | RuleEvaluator (AND/OR conditions) | Pluggable matching logic | ADR-0005 |
+| Singleton | DatabaseHelper, PatternCompiler | Single instance per lifecycle | ADR-0023 |
+| Mixin | BatchOperationsMixin | Reusable batch operations | ADR-0002 |
+| Value Object | All models (immutable, copyWith) | Immutable domain entities | -- |
+
+**References**: [ADR-0002](adr/0002-adapter-pattern-email-providers.md), [ADR-0005](adr/0005-safe-senders-evaluated-before-rules.md), [ADR-0009](adr/0009-provider-pattern-state-management.md)
+
+---
+
+## A6. Technology Architecture
+
+### Current Stack
+
+| Layer | Technology | Purpose |
+|-------|------------|---------|
+| UI Framework | Flutter / Dart | Cross-platform UI and application logic |
+| State Management | Provider | Reactive state via ChangeNotifier ([ADR-0009](adr/0009-provider-pattern-state-management.md)) |
+| Database | SQLite (sqflite/sqflite_ffi) | Persistent storage ([ADR-0010](adr/0010-normalized-database-schema.md)) |
+| Secure Storage | flutter_secure_storage | Credentials via OS-native keystores ([ADR-0008](adr/0008-platform-native-secure-credential-storage.md)) |
+| Email (Gmail) | googleapis | Gmail REST API ([ADR-0034](adr/0034-gmail-access-method-for-production.md)) |
+| Email (IMAP) | enough_mail | IMAP protocol ([ADR-0002](adr/0002-adapter-pattern-email-providers.md)) |
+| OAuth (Mobile) | google_sign_in | Native Google OAuth ([ADR-0011](adr/0011-desktop-oauth-loopback-redirect-pkce.md)) |
+| OAuth (Desktop) | flutter_appauth | Browser-based OAuth + PKCE ([ADR-0011](adr/0011-desktop-oauth-loopback-redirect-pkce.md)) |
+| Desktop Integration | system_tray, window_manager | Windows system tray and window ([ADR-0019](adr/0019-windows-system-tray-integration.md)) |
+| Logging | logger | Keyword-based logging |
+| Build Automation | PowerShell (.ps1 scripts) | Windows builds and deployment ([ADR-0017](adr/0017-powershell-build-automation.md)) |
+| Packaging | MSIX | Windows Store distribution ([ADR-0036](adr/0036-msix-signing-strategy.md)) |
+
+**Package versions**: See `mobile-app/pubspec.yaml` for current dependency versions.
+
+### Target Additions
+
+| Need | Technology Options | Status | Validated |
+|------|--------------------|--------|-----------|
+| Responsive framework | Flutter LayoutBuilder + breakpoints | Not started | Architecture OK |
+| CI/CD pipeline | GitHub Actions | Not started | -- |
+| Linux packaging | Snap, Flatpak, or AppImage | Undecided | Architecture OK |
+| iOS/macOS builds | Xcode + CocoaPods | Not validated | Architecture OK |
+
+**Browser / Flutter Web**: Excluded from target additions. IMAP protocol requires raw TCP sockets blocked by browser Same-Origin Policy. A server-side proxy would contradict the local-only privacy architecture (ADR-0030). See [A3 Gap Analysis](#a3-business-architecture) for details.
+
+### Web Platform Dependency Compatibility (Evaluated April 2026 -- Browser Target Excluded)
+
+The following analysis led to the decision to exclude the browser target. Retained for reference.
+
+| Current Dependency | Web Compatible | Web Alternative | Impact |
+|--------------------|---------------|-----------------|--------|
+| enough_mail (IMAP) | No (TCP sockets blocked) | Server-side IMAP proxy (contradicts ADR-0030) | **Critical**: IMAP providers unavailable without backend |
+| sqflite / sqflite_ffi | No | IndexedDB, Hive, or Drift web | Storage layer rewrite for web |
+| flutter_secure_storage | Limited | Web Crypto API, sessionStorage | Weaker credential security |
+| google_sign_in | Yes | -- | No change needed |
+| googleapis | Yes | -- | No change needed |
+| system_tray | No | N/A (not applicable to web) | Conditionally excluded |
+| window_manager | No | N/A (not applicable to web) | Conditionally excluded |
+
+**Conclusion**: The critical IMAP blocker, combined with the privacy architecture prohibition on server-side proxies, makes the browser target incompatible with the app's core design. See Executive Summary for the full rationale.
+
+**References**: [ADR-0017](adr/0017-powershell-build-automation.md), [ADR-0036](adr/0036-msix-signing-strategy.md)
+
+---
+
+## A7. Architecture Views & Diagrams
+
+Architecture diagrams included in this document:
+
+- **System Context Diagram** (Section A1) -- App boundaries vs external systems
+- **Layered Architecture Diagram** (Section A5) -- 5-layer internal structure
+- **Adapter Pattern Class Diagram** (Section A5) -- Extensibility model
+- **Email Scanning Sequence Diagram** (below) -- Core business flow
+- **Data Flow / Privacy Diagram** (below) -- What data goes where
+- **Platform Deployment Matrix** (below) -- Cross-cutting platform concerns
+
+### Diagram 4: Email Scanning Sequence
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as ScanProgressScreen
+    participant ESP as EmailScanProvider
+    participant ES as EmailScanner
+    participant PR as PlatformRegistry
+    participant Platform as SpamFilterPlatform
+    participant RE as RuleEvaluator
+    participant DB as SQLite Database
+
+    User->>UI: Click "Start Live Scan"
+    UI->>ES: scanInbox(daysBack, folders, scanType)
+    ES->>PR: getPlatform(platformId)
+    PR-->>ES: SpamFilterPlatform instance
+    ES->>ESP: initializePersistence()
+    ES->>ESP: startScan(totalEmails, scanType)
+
+    loop For each folder
+        ES->>ESP: setCurrentFolder(folderName)
+        ES->>Platform: fetchMessages(daysBack, [folder])
+        Platform-->>ES: List of EmailMessage
+
+        loop For each message
+            ES->>RE: evaluate(message)
+            RE-->>ES: EvaluationResult
+            alt Not readonly mode
+                ES->>Platform: takeAction(message, action)
+            end
+            ES->>DB: persistEmailAction()
+            ES->>ESP: updateProgress() [throttled]
+            ESP-->>UI: notifyListeners()
+        end
+    end
+
+    ES->>ESP: completeScan()
+    ESP->>DB: finalizeScanResult()
+    UI->>User: Navigate to ResultsScreen
+```
+
+### Diagram 5: Data Flow / Privacy
+
+```mermaid
+graph LR
+    subgraph "User Device (Trust Boundary)"
+        subgraph "In-Memory Only (Transient)"
+            EMAIL_CONTENT["Email Headers + Body<br/><i>Never persisted</i>"]
+            ACCESS_TOKEN["OAuth Access Tokens<br/><i>Session only</i>"]
+        end
+
+        subgraph "Encrypted at Rest"
+            CREDS["Credentials Store<br/>(OS Keystore)<br/>- Email addresses<br/>- Refresh tokens<br/>- IMAP passwords"]
+        end
+
+        subgraph "Unencrypted Local Storage"
+            SQLITE["SQLite Database<br/>- Scan results metadata<br/>- Rules & safe senders<br/>- App/account settings"]
+            YAML["YAML Files<br/>(Export only)<br/>- Rules backup<br/>- Safe senders backup"]
+        end
+    end
+
+    subgraph "External (Network)"
+        PROVIDER["Email Provider APIs<br/>(Gmail, IMAP)"]
+    end
+
+    PROVIDER -- "Auth tokens" --> ACCESS_TOKEN
+    PROVIDER -- "Email content<br/>(read-only)" --> EMAIL_CONTENT
+    EMAIL_CONTENT -- "Evaluation results<br/>(metadata only)" --> SQLITE
+    CREDS -- "Credentials for auth" --> PROVIDER
+    SQLITE -- "On-demand export" --> YAML
+
+    style EMAIL_CONTENT fill:#fff3cd,stroke:#ffc107
+    style ACCESS_TOKEN fill:#fff3cd,stroke:#ffc107
+    style CREDS fill:#d4edda,stroke:#28a745
+    style SQLITE fill:#d1ecf1,stroke:#17a2b8
+    style YAML fill:#d1ecf1,stroke:#17a2b8
+    style PROVIDER fill:#f8d7da,stroke:#dc3545
+```
+
+**Key Privacy Properties**:
+- Email content is NEVER persisted -- processed in-memory, discarded after evaluation
+- Only evaluation metadata (from address, subject, matched rule) is stored
+- No data transmitted to any server other than email providers for authentication
+- Zero telemetry, zero analytics, zero tracking (ADR-0030)
+
+### Diagram 6: Platform Deployment Matrix
+
+| Platform | Form Factor | Auth Method | Background Scan | Credential Store | Packaging | Distribution | Status |
+|----------|-------------|-------------|-----------------|-----------------|-----------|--------------|--------|
+| **Windows** | Desktop | Browser OAuth + PKCE | Task Scheduler (ADR-0014) | Credential Manager | MSIX (ADR-0036) | Microsoft Store | Production |
+| **macOS** | Desktop | Browser OAuth | launchd (planned) | Keychain | DMG / App Store | Apple App Store | Not validated |
+| **Linux** | Desktop | Browser OAuth | cron / systemd (planned) | libsecret | Snap/Flatpak/AppImage | Direct / Snap Store | Not validated |
+| **Android Phone** | Phone | Native google_sign_in | WorkManager (planned) | Keystore | APK/AAB (ADR-0027) | Google Play | Dev-ready |
+| **Android Tablet** | Tablet | Native google_sign_in | WorkManager (planned) | Keystore | APK/AAB (ADR-0027) | Google Play | Not validated |
+| **iPhone** | Phone | Native google_sign_in | Background App Refresh | Keychain | IPA | Apple App Store | Not validated |
+| **iPad** | Tablet | Native google_sign_in | Background App Refresh | Keychain | IPA | Apple App Store | Not validated |
+| **Browser** | -- | -- | -- | -- | -- | -- | **Excluded** (IMAP incompatible; server-side proxy contradicts ADR-0030) |
+| **Chromebook** | Phone/Tablet/Desktop | Via Android or Linux target | Via Android or Linux target | Via Android or Linux target | APK (Android) or native (Linux) | Google Play / Direct | Via existing targets |
+
+---
+
+## A8. Transition Architectures
+
+### T1: Current State
+
+- Windows production release, Windows Store submission in progress
+- Android debug builds on emulator
+- Gmail dual-path (REST API for testers, IMAP for general users)
+- Background scanning on Windows only
+- See [CHANGELOG.md](../CHANGELOG.md) for current version and test status
+
+### T2: Near-Term (Native Desktop + Mobile)
+
+- Windows Store published
+- Google Play submitted (pending Gmail API verification strategy)
+- macOS and Linux validated and packaged
+- Android tablet layout validated
+- Account deletion feature (ADR-0032) implemented
+- Firebase Analytics removed (ADR-0033)
+
+### T3: Full Native Platforms
+
+- iOS (iPhone + iPad) validated and submitted to Apple App Store
+- Background scanning on Android (WorkManager) and macOS (launchd)
+- Responsive design for phone/tablet/desktop form factors
+- Gmail API CASA verification (if threshold met per ADR-0029)
+
+### T4: Chromebook & Full Platform Matrix
+
+- **Chromebook**: Deployed via Android (Play Store) and/or Linux (Crostini) -- no Flutter Web build required
+- **Browser**: Excluded from the platform matrix. IMAP protocol requires raw TCP sockets incompatible with browser Same-Origin Policy. The only viable approach (a server-side IMAP proxy, as used by browser-based email clients like Outlook Web) would route user credentials and email content through a backend server, directly contradicting the local-only, zero-telemetry privacy architecture (ADR-0030). Chromebook coverage eliminates the primary use case for a browser target.
+- Full responsive design across all form factors
+
+---
+
+# PART B: REQUIREMENTS SPECIFICATION
+
+*Quantitative -- "What must the implementation achieve, and how will we measure compliance?"*
+
+---
+
+## B1. Success Measures & KPIs
+
+| KPI | Target | Measurement Method |
+|-----|--------|-------------------|
+| Test count | No regression (monotonically increasing) | `flutter test` |
+| New code coverage | 80%+ for new code | `flutter test --coverage` |
+| Pattern evaluation (cached) | < 0.5ms (10 patterns) | Stopwatch timing |
+| DB indexed query | < 5ms | Stopwatch timing |
+| Memory (typical ruleset, <500 patterns) | < 10MB | Task Manager / DevTools |
+| Memory (large ruleset, 5000 patterns) | < 50MB | Task Manager / DevTools |
+| App startup (cold) | < 3 seconds (release build) | Stopwatch timing |
+| Scan throughput | < 2ms/email overhead | Stopwatch timing |
+| UI update frequency | Per [ADR-0022](adr/0022-throttled-ui-progress-updates.md) | ADR-defined thresholds |
+| Store certification | Pass on first submission | Store review feedback |
+
+**Current baselines and detailed metrics**: See [PERFORMANCE_BENCHMARKS.md](PERFORMANCE_BENCHMARKS.md)
+
+---
+
+## B2. Business Requirements
+
+| ID | Requirement | Acceptance Criteria | ADR Reference |
+|----|-------------|---------------------|---------------|
+| BR-1 | Multi-provider email filtering | Gmail, AOL, Yahoo, iCloud, custom IMAP, Demo mode all functional | [ADR-0002](adr/0002-adapter-pattern-email-providers.md) |
+| BR-2 | Four progressive scan modes | readonly (default), testLimit, testAll, fullScan with enforcement | [ADR-0006](adr/0006-four-progressive-scan-modes.md) |
+| BR-3 | Safe sender whitelist | Safe senders evaluated before rules, pattern type detection | [ADR-0005](adr/0005-safe-senders-evaluated-before-rules.md) |
+| BR-4 | Multi-account support | Per-account settings with 3-tier inheritance | [ADR-0013](adr/0013-per-account-settings-with-inheritance.md) |
+| BR-5 | Demo mode | Synthetic emails across multiple categories, no live account needed | [ADR-0020](adr/0020-demo-mode-synthetic-emails.md) |
+| BR-6 | Background scanning | Platform-native scheduling (Windows: Task Scheduler) | [ADR-0014](adr/0014-windows-background-scanning-task-scheduler.md) |
+| BR-7 | Move-to-trash safety | All "delete" actions move to trash (recoverable), not permanent delete | [ADR-0007](adr/0007-move-to-trash-not-permanent-delete.md) |
+| BR-8 | Scan history | Persistent scan results with retention settings | [ADR-0010](adr/0010-normalized-database-schema.md) |
+| BR-9 | YAML import/export | Rules and safe senders exportable to YAML for version control | [ADR-0004](adr/0004-dual-write-sqlite-yaml.md) |
+
+**Assumptions**: Users have direct email account access. Single-user per device. Internet required for email scanning.
+
+**Constraints**: No server-side component. Must pass store review for privacy and security.
+
+---
+
+## B3. Data Requirements
+
+| ID | Requirement | Acceptance Criteria | ADR Reference |
+|----|-------------|---------------------|---------------|
+| DR-1 | All user data stored locally | No data transmitted to any server except email providers for auth | [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) |
+| DR-2 | Credentials encrypted at rest | OS-native keystore on every platform | [ADR-0008](adr/0008-platform-native-secure-credential-storage.md) |
+| DR-3 | Email content never persisted | In-memory only during evaluation, discarded after | [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) |
+| DR-4 | Non-destructive schema migrations | All migrations wrapped in transactions, idempotent | [ADR-0021](adr/0021-yaml-to-database-one-time-migration.md) |
+| DR-5 | User data deletion on request | In-app + web page deletion within 30 days | [ADR-0032](adr/0032-user-data-deletion-strategy.md) |
+| DR-6 | Regex-only patterns | All rule patterns are regex, case-insensitive | [ADR-0003](adr/0003-regex-only-pattern-matching.md) |
+| DR-7 | Canonical folder mapping | Provider-specific folder names normalized to standard set | [ADR-0024](adr/0024-canonical-folder-mapping.md) |
+
+---
+
+## B4. Application Requirements
+
+| ID | Requirement | Acceptance Criteria | ADR Reference |
+|----|-------------|---------------------|---------------|
+| AR-1 | Single codebase for all platforms | Flutter/Dart compiles for all targets from one source tree | [ADR-0001](adr/0001-flutter-dart-single-codebase.md) |
+| AR-2 | Adapter interface compliance | New providers implement SpamFilterPlatform; existing tests pass | [ADR-0002](adr/0002-adapter-pattern-email-providers.md) |
+| AR-3 | Reactive UI updates | Provider pattern with ChangeNotifier for all state changes | [ADR-0009](adr/0009-provider-pattern-state-management.md) |
+| AR-4 | Throttled progress updates | Dual-threshold notification per [ADR-0022](adr/0022-throttled-ui-progress-updates.md) | [ADR-0022](adr/0022-throttled-ui-progress-updates.md) |
+| AR-5 | Pattern compilation caching | HashMap cache for repeated patterns (see [ADR-0023](adr/0023-in-memory-pattern-caching.md) for benchmarks) | [ADR-0023](adr/0023-in-memory-pattern-caching.md) |
+| AR-6 | Trash safety enforcement | All delete actions use move-to-trash, never permanent delete | [ADR-0007](adr/0007-move-to-trash-not-permanent-delete.md) |
+| AR-7 | Responsive design | Adaptive layouts for phone (<600dp), tablet (600-900dp), desktop (>900dp) | -- (new requirement) |
+
+---
+
+## B5. Technology Requirements
+
+| ID | Requirement | Acceptance Criteria | ADR Reference |
+|----|-------------|---------------------|---------------|
+| TR-1 | Flutter 3.x / Dart 3.x | Minimum framework version for all builds | [ADR-0001](adr/0001-flutter-dart-single-codebase.md) |
+| TR-2 | SQLite storage | sqflite (mobile), sqflite_ffi (desktop), TBD (web) | [ADR-0010](adr/0010-normalized-database-schema.md) |
+| TR-3 | OAuth 2.0 with PKCE | Desktop OAuth uses browser-based flow with loopback redirect | [ADR-0011](adr/0011-desktop-oauth-loopback-redirect-pkce.md) |
+| TR-4 | MSIX packaging | Windows Store distribution with auto-signing | [ADR-0036](adr/0036-msix-signing-strategy.md) |
+| TR-5 | PowerShell build automation | All Windows build scripts in PowerShell | [ADR-0017](adr/0017-powershell-build-automation.md) |
+| TR-6 | ~~Flutter Web compilation~~ | ~~Chrome, Edge, Safari support~~ | Excluded (IMAP incompatible with browser; see A1 Out of Scope) |
+
+---
+
+## B6. Interoperability Requirements
+
+| ID | External System | Protocol/API | Integration Pattern | ADR Reference |
+|----|----------------|-------------|--------------------|----|
+| IR-1 | Gmail | REST API v1 (googleapis package) | GmailApiAdapter | [ADR-0002](adr/0002-adapter-pattern-email-providers.md), [ADR-0034](adr/0034-gmail-access-method-for-production.md) |
+| IR-2 | AOL, Yahoo, iCloud | IMAP (enough_mail package) | GenericIMAPAdapter | [ADR-0002](adr/0002-adapter-pattern-email-providers.md) |
+| IR-3 | Windows Task Scheduler | COM API via PowerShell | WindowsTaskSchedulerService | [ADR-0014](adr/0014-windows-background-scanning-task-scheduler.md) |
+| IR-4 | OS Credential Stores | Platform-native APIs | flutter_secure_storage | [ADR-0008](adr/0008-platform-native-secure-credential-storage.md) |
+| IR-5 | YAML files | YAML 1.1 | YamlService, YamlExportService | [ADR-0004](adr/0004-dual-write-sqlite-yaml.md) |
+
+---
+
+## B7. Implementation Guidelines
+
+| Area | Standard | Reference Document |
+|------|----------|--------------------|
+| Code quality | 0 analyzer warnings (`flutter analyze`) | [QUALITY_STANDARDS.md](QUALITY_STANDARDS.md) |
+| Testing | TDD approach, 80%+ coverage for new code | [TESTING_STRATEGY.md](TESTING_STRATEGY.md) |
+| Logging | Keyword-based via AppLogger (EMAIL, RULES, EVAL, DB, AUTH, SCAN, ERROR, PERF, UI, DEBUG) | [LOGGING_CONVENTIONS.md](LOGGING_CONVENTIONS.md) |
+| Branching | GitFlow: main <- develop <- feature | [ADR-0015](adr/0015-gitflow-branching-strategy.md) |
+| Changelog | Updated per commit with user-facing changes | [ADR-0025](adr/0025-changelog-per-commit-policy.md) |
+| Sprint process | Phases 1-7 with model tiering | [SPRINT_EXECUTION_WORKFLOW.md](SPRINT_EXECUTION_WORKFLOW.md) |
+| Documentation | No contractions, no emojis, Logger not print() | CLAUDE.md |
+
+---
+
+## B8. Conformance & Compliance Criteria
+
+| ID | Compliance Area | Requirement | Status | ADR Reference |
+|----|----------------|-------------|--------|---------------|
+| CC-1 | Google API Services User Data Policy | Minimum scopes, no selling data, delete on request | Compliant by design | [ADR-0029](adr/0029-gmail-api-scope-and-verification-strategy.md), [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) |
+| CC-2 | Microsoft Store certification | MSIX signed, privacy policy linked, content rating | In progress | [ADR-0036](adr/0036-msix-signing-strategy.md) |
+| CC-3 | Google Play privacy policy | Publicly accessible, consistent with Data Safety form | Policy drafted | [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md) |
+| CC-4 | GDPR/CCPA | Local-only processing, data deletion on request, no tracking | Compliant by design | [ADR-0030](adr/0030-privacy-and-data-governance-strategy.md), [ADR-0032](adr/0032-user-data-deletion-strategy.md) |
+| CC-5 | Gmail API CASA audit | Required when >2,500 users or >$5K/yr revenue | Deferred | [ADR-0029](adr/0029-gmail-api-scope-and-verification-strategy.md) |
+| CC-6 | Android permissions | Minimum required permissions, runtime requests | Defined | [ADR-0028](adr/0028-android-permission-strategy.md) |
+| CC-7 | Android release signing | Play App Signing enrollment | Defined | [ADR-0027](adr/0027-android-release-signing-strategy.md) |
+
+---
+
+# PART C: TRACEABILITY & GOVERNANCE
+
+---
+
+## C1. Decision-to-Requirement Traceability Matrix
+
+### Domain-Level View
+
+[ADRs](adr/README.md) grouped into 7 architectural domains, mapped to requirements sections:
+
+| Domain | ADRs | B2 Business | B3 Data | B4 Application | B5 Technology | B6 Interop | B8 Compliance |
+|--------|------|-------------|---------|----------------|---------------|------------|---------------|
+| **Core Architecture** (9) | 0001, 0002, 0003, 0005, 0006, 0007, 0009, 0022, 0023 | BR-1,2,3,7 | DR-6 | AR-1,2,3,4,5,6 | TR-1 | IR-1,2 | -- |
+| **Data & Storage** (6) | 0004, 0010, 0012, 0013, 0021, 0024 | BR-4,8,9 | DR-4,7 | -- | TR-2 | IR-5 | -- |
+| **Security & Auth** (2) | 0008, 0011 | -- | DR-2 | -- | TR-3 | IR-4 | -- |
+| **Platform Integration** (6) | 0014, 0017, 0018, 0019, 0020, 0035 | BR-5,6 | -- | -- | TR-4,5 | IR-3 | -- |
+| **Privacy & Compliance** (5) | 0029, 0030, 0032, 0033, 0034 | -- | DR-1,3,5 | -- | -- | -- | CC-1,3,4,5 |
+| **Release & Distribution** (7) | 0026, 0027, 0028, 0031, 0036 + 0015, 0025 | -- | -- | -- | TR-4 | -- | CC-2,6,7 |
+| **DevOps & Process** (1) | 0016 | -- | -- | -- | -- | -- | -- |
+
+---
+
+## C2. Gap-to-Requirement Mapping
+
+| Gap (from A3-A6) | Requirement(s) Addressing It | Priority |
+|-------------------|------------------------------|----------|
+| macOS/Linux/iOS not validated | AR-1, TR-1 | Medium |
+| Google Play submission on hold | CC-1, CC-3, CC-5, CC-6, CC-7 | Medium (blocked on ADR-0029) |
+| Apple App Store not started | New ADR needed | Low |
+| Flutter Web / Browser | -- | Excluded (IMAP incompatible; server-side proxy contradicts ADR-0030) |
+| Chromebook | -- | Low (served by Android/Linux targets) |
+| Responsive design not started | AR-7 (new) | Medium |
+| Account deletion UI | DR-5, CC-4 | Medium |
+| Analytics dependency cleanup | CC-3 (Data Safety form) | Low |
+| Pattern cache unbounded | AR-5 (known issue #16) | Low |
+| No CI/CD pipeline | -- (efficiency, not architectural) | Low |
+
+---
+
+## C3. Risk Register
+
+| ID | Risk | Impact | Likelihood | Mitigating ADR(s) | Mitigation Strategy |
+|----|------|--------|------------|-------------------|---------------------|
+| R1 | Gmail API verification rejected | Cannot distribute on Play Store with OAuth | Medium | ADR-0029, ADR-0034 | Dual-path: IMAP app passwords as fallback |
+| R2 | Store certification failure | Delayed distribution | Low | ADR-0030, ADR-0036 | Privacy-by-design, pre-certification testing |
+| R3 | Pattern cache memory growth | OOM on large rulesets | Low | ADR-0023 | LRU cache planned (Issue #16) |
+| R4 | IMAP provider API changes | Provider adapter breaks | Low | ADR-0002 | Adapter isolation limits blast radius |
+| R5 | Credential storage breach | User account compromise | Low | ADR-0008 | OS-native encryption, no custom crypto |
+| R6 | Migration data loss | Rules lost on upgrade | Low | ADR-0021 | Transaction-wrapped, idempotent migrations |
+| R7 | Browser IMAP incompatibility | IMAP providers unavailable in browser (TCP sockets blocked by Same-Origin Policy) | **Resolved** | ADR-0002, ADR-0030 | Browser target excluded; server-side proxy contradicts local-only privacy architecture |
+| R8 | Browser storage/credential limits | sqflite incompatible with web; credentials weaker than native keystores | **Resolved** | ADR-0008, ADR-0010 | Browser target excluded; no web storage or credential adaptation needed |
+| R9 | Tablet UX inadequate | Poor user experience on tablets | Low | -- | Responsive breakpoints, adaptive layouts |
+
+---
+
+## C4. Change Log & Requirements Impact History
+
+| Date | Change | Impact | Sections Affected |
+|------|--------|--------|-------------------|
+| 2026-04-03 | Initial ARS&D document created | Baseline established | All |
+| 2026-04-10 | Review pass 1: corrected ADR counts, table counts | Accuracy fixes | Executive Summary, A2, A4, A6, Appendix D |
+| 2026-04-10 | Deduplicated counts across ARSD/ARCHITECTURE/ADR docs | Maintenance reduction | All sections with counts |
+| 2026-04-10 | Platform expansion validation for Android, iOS, Browser, Chromebook | Browser target blocked (IMAP incompatible); Chromebook served by Android/Linux | A3, A4, A6, A8, C2, C3, Diagram 6 |
+| 2026-04-11 | Browser target formally excluded | Moved from "Blocked" to "Excluded"; IMAP+privacy rationale documented across ARSD, ARCHITECTURE, ADR-0001, ADR-0030 | Exec Summary, A1, A3, A4, A6, A8, B5, C2, C3, Diagram 6 |
+
+---
+
+# APPENDICES
+
+---
+
+## Appendix A: Glossary
+
+| Term | Definition |
+|------|-----------|
+| **SpamFilterPlatform** | Abstract class defining the email provider interface (ADR-0002) |
+| **PlatformRegistry** | Factory that instantiates email provider adapters by platform ID |
+| **EvaluationResult** | Value object containing the outcome of evaluating one email against all rules |
+| **ScanMode** | Enum: readonly, testLimit, testAll, fullScan (ADR-0006) |
+| **CanonicalFolder** | Normalized folder names across providers: INBOX, JUNK, TRASH, SENT, DRAFTS, ARCHIVE, CUSTOM |
+| **Dual-Write** | Pattern where data is written to SQLite (primary) and YAML (secondary) simultaneously |
+| **Safe Sender** | A regex pattern on the whitelist; emails from matching senders bypass all rules |
+| **PatternCompiler** | Service that compiles and caches regex patterns for efficient matching ([ADR-0023](adr/0023-in-memory-pattern-caching.md)) |
+| **Three-Tier Settings** | Inheritance chain: account_settings -> app_settings -> hardcoded defaults |
+| **CASA** | Cloud Application Security Assessment, required for Gmail API restricted scopes at scale |
+| **ARS&D** | Architecture Requirements Specification & Design (this document) |
+
+---
+
+## Appendix B: Reference Models
+
+### SpamFilterPlatform Interface
+
+The primary architectural building block. All email providers must implement this interface. See [ADR-0002](adr/0002-adapter-pattern-email-providers.md) for full specification.
+
+### PlatformRegistry Factory Map
+
+```
+'aol'    -> GenericIMAPAdapter.aol()
+'gmail'  -> GmailApiAdapter()
+'yahoo'  -> GenericIMAPAdapter.yahoo()
+'icloud' -> GenericIMAPAdapter.icloud()
+'imap'   -> GenericIMAPAdapter.custom()
+'demo'   -> MockEmailProvider()
+```
+
+### Three-Tier Settings Inheritance
+
+```
+Query: getSettingValue(accountId, key)
+  1. Check account_settings[accountId][key]  -> if found, return
+  2. Check app_settings[key]                 -> if found, return
+  3. Return hardcoded default                -> always available
+```
+
+See [ADR-0013](adr/0013-per-account-settings-with-inheritance.md) for details.
+
+---
+
+## Appendix C: Rule Evaluation Algorithm
+
+```
+evaluate(EmailMessage):
+  1. SafeSenderList.findMatch(email.from)
+     -> Match? Return safeSender result (STOP)
+  2. For each Rule (sorted by executionOrder):
+     a. Check exceptions first
+        -> Exception matched? Skip this rule (CONTINUE)
+     b. Check conditions (AND/OR logic)
+        -> Conditions matched? Return action result (STOP)
+  3. No match -> Return noMatch result
+```
+
+See [ADR-0005](adr/0005-safe-senders-evaluated-before-rules.md) for rationale.
+
+---
+
+## Appendix D: ADR Index
+
+For the complete ADR index with current status, see [docs/adr/README.md](adr/README.md).
+
+The domain groupings used in the [C1 Traceability Matrix](#c1-decision-to-requirement-traceability-matrix) are:
+
+| Domain | ADR Range | Purpose |
+|--------|-----------|---------|
+| Core Architecture | 0001-0009, 0022-0023 | Fundamental design patterns and principles |
+| Data & Storage | 0004, 0010, 0012-0013, 0021, 0024 | Database, file system, settings |
+| Security & Auth | 0008, 0011 | Credential storage and OAuth |
+| Platform Integration | 0014, 0017-0020, 0035 | OS-specific features |
+| Privacy & Compliance | 0029-0030, 0032-0034 | Privacy, compliance, Gmail access |
+| Release & Distribution | 0015, 0025-0028, 0031, 0036 | Build, packaging, store submission |
+| DevOps & Process | 0016 | Sprint methodology |
+
+---
+
+**Document End**
+
+*This ARS&D document is a TOGAF-tailored deliverable per [ADR-2026-04-003](). It combines the Architecture Definition Document (ADD) and Architecture Requirements Specification (ARS) with structured separation (Part A / Part B / Part C). Individual ADRs remain the authoritative source for specific architectural decisions.*

--- a/docs/PRESENTATION_FRAMEWORK.md
+++ b/docs/PRESENTATION_FRAMEWORK.md
@@ -1,0 +1,496 @@
+# GenAI Happy Hour Presentation: Building a Real App with Claude Code
+
+**Audience**: Developers (Python, Go, TypeScript, C#/.NET) at GenAI Happy Hour
+**Format**: ~25-30 min talk + Q&A
+**Tone**: Honest, practical, developer-to-developer
+**Total Slides**: ~27 slides
+
+---
+
+## SECTION 1: Introduction (2 slides)
+
+### Slide 1: Title
+
+**"From Side Project to Windows Store: Building a Real App with Claude Code"**
+
+- Harold Kimmey
+- GenAI Happy Hour - [Date]
+- Subtitle: "25 sprints, 1,178 tests, 0 regressions"
+
+---
+
+### Slide 2: The Problem and Starting Point
+
+**I was drowning in spam across multiple email accounts.**
+
+- Had a working Python/Outlook desktop script (win32com, hardcoded rules, Windows-only)
+- Each email provider has different spam filtering quality
+- Wanted: one app, all providers, all platforms, portable rules
+- "I am not a Flutter developer. I had never written Dart. This is relevant."
+
+> **Talking point**: "I had a working solution. But it was duct tape and baling wire. I wanted a real app — and I wanted to see if Claude Code could help me build one."
+
+---
+
+## SECTION 2: App Functionality (2 slides, ~10 bullet points)
+
+### Slide 3: What MyEmailSpamFilter Does — Core Features
+
+**Email Scanning and Filtering**
+- Connects to Gmail (OAuth), AOL, Yahoo, and any generic IMAP provider
+- Evaluates emails against 3,291 regex-based spam rules with first-match-wins logic
+- Safe sender whitelist — trusted senders bypass all rules automatically
+- Four progressive scan modes: read-only (default), test limit, safe-senders-only, full production
+- Move-to-trash safety — never permanently deletes; recoverable from trash
+
+**Multi-Account Management**
+- Add and manage multiple email accounts across different providers
+- Per-account folder selection and scan configuration
+
+---
+
+### Slide 4: What MyEmailSpamFilter Does — Advanced Features
+
+**Background and Automation**
+- Scheduled background scanning via Windows Task Scheduler (headless, no UI)
+- System tray icon with context menu; toast notifications on scan completion
+- Scan history with retention settings — review what was caught and when
+
+**Rules Management**
+- Search, browse, and manage 3,291+ individual rules organized by pattern type
+- Add block rules or safe senders inline during scan results review
+- Rule conflict detection — warns when rules prevent other rules from firing
+- Import/export rules via YAML for version control and portability
+
+---
+
+## SECTION 3: Application Screenshots (12 slides)
+
+> **Note**: Capture these screenshots from the running Windows app before the talk. Each slide should be a full-screen or near-full-screen screenshot with a short title and 1-2 bullet annotations.
+
+### Slide 5: Account Selection Screen
+
+**Screenshot**: `AccountSelectionScreen` — the landing page
+
+- List of configured email accounts (Gmail, AOL, etc.)
+- Add Account button, account status indicators
+- Bottom navigation bar on Android; traditional nav on Windows
+
+> **Source file**: `lib/ui/screens/account_selection_screen.dart`
+
+---
+
+### Slide 6: Platform Selection Screen
+
+**Screenshot**: `PlatformSelectionScreen` — choosing an email provider
+
+- Provider cards: Gmail, AOL, Yahoo, Generic IMAP, Demo Mode
+- Each card shows supported auth method (OAuth, App Password, IMAP)
+
+> **Source file**: `lib/ui/screens/platform_selection_screen.dart`
+
+---
+
+### Slide 7: Account Setup / Gmail OAuth Screen
+
+**Screenshot**: `AccountSetupScreen` or `GmailOAuthScreen` — configuring an account
+
+- Credential entry (IMAP) or OAuth browser flow (Gmail)
+- Folder selection for which folders to scan
+- Scan mode configuration
+
+> **Source files**: `lib/ui/screens/account_setup_screen.dart`, `lib/ui/screens/gmail_oauth_screen.dart`
+
+---
+
+### Slide 8: Folder Selection Screen
+
+**Screenshot**: `FolderSelectionScreen` — picking email folders to scan
+
+- Tree view of IMAP folders
+- Checkbox selection for folders to include
+- Junk folder auto-detection per provider (AOL: Bulk Mail, Gmail: Spam, etc.)
+
+> **Source file**: `lib/ui/screens/folder_selection_screen.dart`
+
+---
+
+### Slide 9: Scan Progress Screen
+
+**Screenshot**: `ScanProgressScreen` — live scan in progress
+
+- Real-time progress bar with email count
+- Throttled UI updates (every 10 emails or every 2 seconds)
+- Current folder, emails processed, matches found
+
+> **Source file**: `lib/ui/screens/scan_progress_screen.dart`
+
+---
+
+### Slide 10: Scan Results Screen
+
+**Screenshot**: `ResultsDisplayScreen` — scan results with filtering
+
+- Email list showing: folder, subject, matched rule
+- Filter chips by category (spam type, safe sender, no match)
+- Search bar for finding specific results
+- Inline actions: add as safe sender, add block rule
+
+> **Source file**: `lib/ui/screens/results_display_screen.dart`
+
+---
+
+### Slide 11: Email Detail View
+
+**Screenshot**: `EmailDetailView` — drilling into a specific email
+
+- Full email headers (From, Subject, Date)
+- Matched rule name and pattern that triggered
+- Action taken (moved to trash, no action, safe sender)
+
+> **Source file**: `lib/ui/screens/email_detail_view.dart`
+
+---
+
+### Slide 12: Rules Management Screen
+
+**Screenshot**: `RulesManagementScreen` — browsing 3,291 rules
+
+- Searchable rule list with pattern type classification
+- Rule details: name, conditions (from/subject/body/header patterns), actions
+- Enabled/disabled toggle
+
+> **Source file**: `lib/ui/screens/rules_management_screen.dart`
+
+---
+
+### Slide 13: Safe Senders Management Screen
+
+**Screenshot**: `SafeSendersManagementScreen` — whitelist management
+
+- Three pattern types: exact email, exact domain, entire domain (with subdomains)
+- Category filter chips to view by type
+- Add/remove safe sender entries
+
+> **Source file**: `lib/ui/screens/safe_senders_management_screen.dart`
+
+---
+
+### Slide 14: Rule Test Screen
+
+**Screenshot**: `RuleTestScreen` — testing patterns against sample emails
+
+- Enter a regex pattern, test against sample emails
+- Match highlighting showing which emails would be caught
+- Useful for refining rules before deploying
+
+> **Source file**: `lib/ui/screens/rule_test_screen.dart`
+
+---
+
+### Slide 15: Settings Screen
+
+**Screenshot**: `SettingsScreen` — tabbed configuration
+
+- Tabs: Manual Scan, Background Scan, Account, Import/Export
+- Scan mode selection, folder configuration, frequency settings
+- YAML import/export for rule portability
+
+> **Source file**: `lib/ui/screens/settings_screen.dart`
+
+---
+
+### Slide 16: Scan History Screen
+
+**Screenshot**: `ScanHistoryScreen` — historical scan results
+
+- Unified view of manual and background scans
+- Per-scan stats: emails processed, deleted, moved, safe, errors
+- Retention settings for history cleanup
+
+> **Source file**: `lib/ui/screens/scan_history_screen.dart`
+
+---
+
+## SECTION 4: Architecture (4 slides)
+
+### Slide 17: Architecture Decision — Why Flutter/Dart?
+
+**Key Requirement**: One codebase, 5 platforms, multiple display sizes
+
+| Considered | Rejected Because |
+|------------|-----------------|
+| Keep Python + build separate mobile apps | Rule engine reimplemented 3x; maintenance unsustainable for solo dev |
+| React Native | Desktop support (Electron) was less mature at decision time |
+| Kotlin Multiplatform (KMP) | Still requires separate UI per platform |
+| .NET MAUI | No Linux support; too coupled to Microsoft ecosystem |
+| **Flutter/Dart** | **Chosen**: single UI framework, all 5 platforms, strong desktop story |
+
+> **Talking point**: "This was ADR-0001. We documented the decision with alternatives considered, pros/cons, and consequences. This is how every major decision was made."
+
+---
+
+### Slide 18: Layered Architecture
+
+```
++-----------------------------------------------+
+|              UI Layer (Flutter)                |
+|  Material Design - responsive to device size  |
++-----------------------------------------------+
+|        State Management (Provider)            |
+|  RuleSetProvider | EmailScanProvider          |
++-----------------------------------------------+
+|            Core Services                      |
+|  RuleEvaluator | EmailScanner | PatternCompiler|
+|  RuleConflictDetector | YamlService           |
++-----------------------------------------------+
+|            Adapter Layer                      |
+|  GmailApiAdapter | GenericIMAPAdapter         |
+|  MockEmailProvider (Demo)                     |
++-----------------------------------------------+
+|          Platform Services                    |
+|  AppPaths | SecureCredentials | SQLite DB     |
+|  TaskScheduler | SystemTray | Notifications   |
++-----------------------------------------------+
+```
+
+**Key design pattern**: Provider-agnostic core. Add a new email provider by implementing one interface (`SpamFilterPlatform`). Business logic never changes.
+
+---
+
+### Slide 19: The ADR Process — Architecture Decision Records
+
+**36 ADRs documented across 25 sprints** ([docs/adr/](docs/adr/))
+
+**Format** (every ADR follows this template):
+- **Context**: What problem motivated this decision?
+- **Decision**: What was decided?
+- **Alternatives Considered**: What else was evaluated, with pros/cons?
+- **Consequences**: Positive, negative, and neutral trade-offs
+
+**Example ADRs that shaped the app**:
+
+| ADR | Decision | Impact |
+|-----|----------|--------|
+| 0001 | Flutter/Dart single codebase | 5 platforms from 1 codebase |
+| 0002 | Adapter pattern for email providers | Add providers without touching core |
+| 0006 | Four progressive scan modes | Safety: never accidentally delete in dev |
+| 0007 | Move-to-trash, not permanent delete | User trust and recoverability |
+| 0023 | In-memory pattern caching | 100x performance improvement (2.1ms to 0.18ms) |
+| 0035 | Dev/prod side-by-side builds | Run dev and production on same machine |
+
+> **Talking point**: "The ADR-first approach was a lesson from Sprint 21. Design the ADR in one sprint, get review, implement in the next. Less rework, better results."
+
+---
+
+### Slide 20: Platform-Specific Adaptations
+
+**One codebase, different behaviors per platform**:
+
+| Capability | Windows | Android | macOS/Linux/iOS |
+|-----------|---------|---------|-----------------|
+| OAuth | Browser loopback redirect + PKCE | Native Google Sign-In | Browser-based (planned) |
+| Background scan | Windows Task Scheduler | WorkManager (infra ready) | Planned |
+| Notifications | PowerShell toast via WinRT | System notifications | Planned |
+| System tray | Native tray icon + context menu | N/A | Planned |
+| Storage | `AppData\Roaming\MyEmailSpamFilter\` | App-private `/data/` | Platform-specific paths |
+| Navigation | Traditional nav (no bottom bar) | Bottom navigation bar | TBD |
+| Packaging | MSIX (Windows Store) | APK/AAB | TBD |
+
+**Handled via**:
+- `AppPaths` abstraction (ADR-0012) for storage
+- `Platform.isAndroid` / `Platform.isWindows` for UI behavior
+- Platform-specific adapter implementations behind common interfaces
+
+---
+
+## SECTION 5: Agile/Scrum Process (3 slides)
+
+### Slide 21: Sprint Methodology — Not "Write Me an App"
+
+**7-Phase Sprint Execution Workflow**:
+
+```
+Phase 1: Pre-Sprint     -> Verify environment, restore context
+Phase 2: Planning        -> Review backlog, select cards, define acceptance criteria
+Phase 3: Plan Approval   -> I review and approve -> AUTONOMOUS EXECUTION AUTHORIZED
+Phase 4: Execution       -> Claude works continuously, no per-task approval needed
+Phase 5: Testing         -> Full test suite, lint, analyze
+Phase 6: PR + Review     -> Create PR to develop (never main), I review
+Phase 7: Retrospective   -> What worked, what did not, process improvements
+```
+
+**Key insight**: Phase 3 approval pre-authorizes ALL implementation decisions. This eliminated the biggest bottleneck: me approving every task. Sprint velocity doubled after Sprint 6 when this was formalized.
+
+**Sprint cadence**: 25 sprints in ~2 months. Sprints ranged from 3 hours (focused research) to 20 hours (major refactoring).
+
+---
+
+### Slide 22: Model Tiering — Right Tool for the Job
+
+**Not every task needs the biggest model.**
+
+| Model | Complexity | Used For | Example Task |
+|-------|-----------|----------|--------------|
+| **Haiku** | Low | Bug fixes, tests, docs, single-file changes | "Add 15 unit tests for PatternCompiler" |
+| **Sonnet** | Medium | Multi-file refactoring, architecture research | "Restructure Settings screen into tabbed layout" |
+| **Opus** | High | Deep debugging, performance, critical path | "Split 5 monolithic rules into 3,291 individual rules" |
+
+**Escalation path**: Haiku encounters blocker -> escalate to Sonnet -> escalate to Opus -> report to user
+
+**Result**: Model assignment was 100% accurate across all sprints. Heuristic is simple:
+- Touches 1 file? Haiku.
+- Multiple files with design decisions? Sonnet.
+- Would I lose sleep over a bug in it? Opus.
+
+---
+
+### Slide 23: Process Artifacts That Made It Work
+
+**11 documents govern sprint execution** ([docs/](docs/)):
+
+| Document | Purpose |
+|----------|---------|
+| `CLAUDE.md` | Project constitution — read first every session |
+| `ALL_SPRINTS_MASTER_PLAN.md` | Backlog, priorities, feature details |
+| `SPRINT_EXECUTION_WORKFLOW.md` | 7-phase checklist |
+| `SPRINT_STOPPING_CRITERIA.md` | Exactly when to stop (9 criteria) |
+| `TESTING_STRATEGY.md` | What to test, how, coverage expectations |
+| `ARCHITECTURE.md` | System design reference |
+| 36 ADRs | Every major decision documented |
+| Per-sprint docs | Plan, retrospective, summary for each sprint |
+
+**Why this matters**: Claude Code sessions are **stateless** — context resets between conversations. Documentation IS the memory. Each new session reads CLAUDE.md and picks up where the last one left off.
+
+> **Talking point**: "This is the unsexy part. But it is the difference between 'Claude wrote some code' and 'Claude delivered 25 consecutive sprints.'"
+
+---
+
+### Slide 24: The Claude Code Instruction Stack
+
+**CLAUDE.md — the project constitution (691 lines)**
+
+Everything Claude needs to know, read automatically at session start:
+- Project overview, repo structure, common commands
+- Coding style (no contractions, no emojis, Logger not print)
+- Development workflow (sprints, not phases)
+- Branch policy (PRs to develop, never main)
+- Co-lead developer philosophy
+- Sprint autonomy rules (do not stop for per-task approval)
+- Platform constraints (Windows primary, PowerShell, no jq/sed/awk)
+
+**Custom Skills** (`.claude/skills/` — 9 skills):
+
+| Skill | What It Does |
+|-------|-------------|
+| `/startup-check` | Verify environment, restore saved context — run FIRST every session |
+| `/plan-sprint` | Analyze issues, generate task breakdown with model assignments |
+| `/phase-check` | Sprint phase transition checkpoint |
+| `/full-test` | Run all Flutter tests + analyze code quality |
+| `/memory-save` | Save sprint context to file for next session |
+| `/memory-restore` | Restore sprint context from saved memory |
+| `/validate-rules` | Validate YAML rule files for syntax and regex errors |
+| `/deploy-debug` | Build, install, and launch debug APK on emulator |
+| `/first-principles` | Deconstruct problems to fundamentals when stuck |
+
+> **Talking point**: "Skills are reusable prompts. `/startup-check` runs every session — it verifies git, GitHub CLI, and restores memory. Without it, every session starts from scratch."
+
+---
+
+### Slide 25: Memory, Commands, and Agents
+
+**The Stateless Problem**: Claude Code has no memory between sessions. Every conversation starts fresh.
+
+**Memory System** (`.claude/memory/`):
+- `/memory-save` serializes current sprint context (active sprint, completed tasks, blockers, decisions made) to `current.md`
+- `/memory-restore` loads it back at session start via `/startup-check`
+- PowerShell scripts (`save-memory.ps1`, `check-memory-on-startup.ps1`) automate the process
+- "Document for amnesia" — if it is not written down, it does not exist
+
+**Slash Commands** (`.claude/commands/` — 5 commands):
+- `/quick-commit` — Stage all changes, generate descriptive commit message
+- `/commit-push-pr` — Full commit, push, and open PR workflow
+- `/review-changes` — Review uncommitted changes and suggest improvements
+- `/test-and-fix` — Run tests and automatically fix failures
+- `/first-principles` — Break down problems when conventional approaches fail
+
+**Agents** (`.claude/agents/` — 5 agents):
+- `build-validator` — Verify builds pass on target platforms
+- `code-architect` — Architectural analysis and recommendations
+- `code-simplifier` — Review for reuse, quality, efficiency
+- `oncall-guide` — Troubleshooting guidance
+- `verify-app` — Application verification checks
+
+**Cumulative investment**: These artifacts were built over 25 sprints. Each sprint added or refined instructions. By Sprint 25, a new Claude session can pick up any task with full context in under 2 minutes.
+
+> **Talking point**: "This is the compounding return. Sprint 1 had just a CLAUDE.md. By Sprint 25, there is a full instruction stack — skills, memory, commands, agents, 11 process docs, 36 ADRs. Each session starts smarter than the last."
+
+---
+
+## SECTION 6: Team Roles (1 slide)
+
+### Slide 26: Application and Team Roles
+
+**Human Roles (Harold Kimmey)**:
+
+| Role | Responsibility |
+|------|---------------|
+| Customer Representative | Real-world requirements, acceptance criteria from user perspective |
+| Product Owner | Backlog priority, sprint scope approval, trade-off decisions |
+| Chief Architect | Final architectural decisions, ADR approval |
+| Chief Developer | PR approval, manual testing, merge-to-main authority |
+| Scrum Master | Sprint ceremonies, timeline, scope discipline |
+| Lead Test Engineer | Test strategy, exploratory testing, quality approval |
+
+**Claude Code Team Roles**:
+
+| Role | Model | Responsibility |
+|------|-------|---------------|
+| Lead Developer | Opus | Critical path features, deep debugging, performance |
+| Senior Developers | Sonnet | Architecture, complex refactoring, multi-file changes |
+| Developers | Haiku | Implementation, bug fixes, tests, documentation |
+| Assistant Scrum Master | All | Sprint checklist execution, status tracking, docs |
+| Architecture Dev Team | All | ADR research, gap analysis, design implementation |
+| Senior Test Engineers | All | Unit/integration tests, test suite, failure analysis |
+
+> **Talking point**: "I own the 'what' and 'why.' Claude owns the 'how.' Every role maps to a real Scrum role — this is not a novelty, it is a working team structure."
+
+---
+
+## SECTION 7: Closing (1 slide)
+
+### Slide 27: Key Takeaways and Q&A
+
+**What I learned in 25 sprints**:
+
+1. **Write a good CLAUDE.md** — Single highest-leverage investment. It is the project constitution.
+2. **Use sprints, not prompts** — "Build me X" produces demos. Sprints produce software.
+3. **Document for amnesia** — Every session starts fresh. If it is not written down, it does not exist.
+4. **Tests are non-negotiable** — Make it acceptance criteria. Claude will write them if required.
+5. **The human is the bottleneck** — Autonomous execution post-approval doubled velocity.
+
+**Questions I expect**:
+- "How much code did YOU write?" -> ~5% me, 95% Claude. 100% of decisions were collaborative.
+- "Would this work for a team?" -> Yes, with good CLAUDE.md and branch strategy.
+- "What about other languages?" -> Claude Code is language-agnostic. Sprint methodology works for any stack.
+- "Is the code good?" -> 0 analyzer warnings, adapter pattern, 1,178 tests, 36 ADRs. You tell me.
+
+**GitHub**: github.com/kimmeyh/spamfilter-multi
+
+---
+
+## Presentation Notes
+
+- **Total slides**: 27 (Title + 1 Intro + 2 Functionality + 12 Screenshots + 4 Architecture + 3 Agile + 2 Instruction Stack + 1 Roles + 1 Closing/Q&A)
+- **Screenshots**: Capture from the running Windows app before the talk. Use the Demo Mode (55 synthetic emails) to populate realistic scan results without exposing real email data.
+- **Live demo option**: Consider a 2-minute live demo scan using Demo Mode if time permits.
+- **Timing guide**:
+  - Intro + Functionality: 3-4 min
+  - Screenshots walkthrough: 8-10 min (move quickly, ~45 sec per screen)
+  - Architecture: 5-6 min
+  - Agile/Scrum: 4-5 min
+  - Instruction Stack (CLAUDE.md, Skills, Memory): 3-4 min
+  - Roles + Closing: 2-3 min
+  - Q&A: remaining time
+- **For the developer audience**: They will care most about the ADR process, the architecture decisions, and the sprint methodology. Do not rush the architecture section.
+- **Handout**: Consider sharing the "Key Takeaways" slide as a one-pager, plus a link to the repo.

--- a/docs/adr/0001-flutter-dart-single-codebase.md
+++ b/docs/adr/0001-flutter-dart-single-codebase.md
@@ -24,11 +24,16 @@ Key forces driving this decision:
 
 Use 100% Flutter/Dart for all platforms with a single codebase. The original Python desktop application is archived (retained as reference in `archive/desktop-python/`) and all new development uses Flutter.
 
-The application targets all five platforms from a single `mobile-app/` directory:
+The application targets all five native platforms from a single `mobile-app/` directory:
 - Android and iOS (mobile)
 - Windows, macOS, and Linux (desktop)
+- Chromebook users are served by the Android (Play Store) and Linux (Crostini) targets
 
 All business logic (rule evaluation, pattern compilation, email scanning) lives in `lib/core/` and is completely platform-agnostic. Platform-specific code is isolated in `lib/adapters/` behind abstract interfaces.
+
+### Browser / Flutter Web (Excluded)
+
+A browser target (Flutter Web) has been evaluated and excluded. The app's IMAP-based email providers (AOL, Yahoo, iCloud, custom IMAP) require raw TCP socket connections via the `enough_mail` package, which browsers block via the Same-Origin Policy. The only viable workaround is a server-side IMAP proxy (the approach used by browser-based email clients such as Outlook Web), which would route user credentials and email content through a backend server. This directly contradicts the local-only, zero-telemetry privacy architecture ([ADR-0030](0030-privacy-and-data-governance-strategy.md)). A Gmail-only browser version (Gmail REST API works over HTTPS) was considered but rejected as it would exclude all IMAP providers, offering a degraded product that does not justify the engineering and maintenance cost.
 
 ## Alternatives Considered
 

--- a/docs/adr/0027-android-release-signing-strategy.md
+++ b/docs/adr/0027-android-release-signing-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -47,52 +47,59 @@ The signing configuration must integrate with this PowerShell build infrastructu
 
 ## Decision
 
-**TO BE DETERMINED** - This ADR captures the decision criteria. The decision will be made by the Product Owner.
+**Option B: Build-time keystore injection via PowerShell script**, extending the existing `build-with-secrets.ps1` pattern. Enroll in Google Play App Signing. Build AAB format for Play Store, APK for local testing.
 
-### Options Under Consideration
+### Implementation Details
 
-#### Option A: Keystore in Local File with Environment Variables
-- Store keystore `.jks` file on local disk (outside repository)
-- Reference via environment variables in `build.gradle.kts`
-- `key.properties` file (gitignored) points to keystore location
-- Similar to Flutter's recommended approach
+- Keystore `.jks` file stored in a secure location outside the repository (e.g., encrypted vault, cloud storage backup)
+- PowerShell build script injects keystore path, alias, and passwords at build time
+- `key.properties` file is NOT used (avoids persistent credential file on disk in repo tree)
+- Signing config in `build.gradle.kts` reads from environment variables or `--dart-define` parameters
+- Play App Signing enrollment required (Google manages the app signing key; developer manages the upload key)
+- Upload key can be reset via Play Console if lost
 
-#### Option B: Keystore Injected at Build Time (Like Secrets)
-- Store keystore in a secure location (e.g., encrypted vault, cloud storage)
-- Inject at build time via PowerShell script (similar to `build-with-secrets.ps1`)
-- Keystore never persists on disk in the repository tree
+### Build Outputs
 
-#### Option C: GitHub Actions / CI-Based Signing
-- Keystore stored as GitHub Actions secret (base64-encoded)
-- Signing happens in CI/CD pipeline
-- Local development uses debug keys; only CI produces release builds
-
-### Decision Criteria
-
-1. **Security**: Keystore and passwords must never be committed to version control
-2. **Backup**: Keystore must be recoverable if the development machine is lost
-3. **Integration**: Must work with existing PowerShell build scripts
-4. **Play App Signing**: Whether to enroll (recommended by Google, adds safety net)
-5. **CI/CD compatibility**: Should support future CI/CD pipeline integration
-6. **Simplicity**: Developer should be able to produce release builds easily
-7. **AAB vs APK**: Build scripts must produce AAB format for Play Store upload
+- **APK**: For local testing and emulator deployment (`build-with-secrets.ps1 -BuildType debug`)
+- **AAB**: For Google Play Store upload (release builds only)
 
 ### Key Points
 
 - Play App Signing is mandatory for AAB uploads and strongly recommended
 - With Play App Signing, Google manages the actual signing key; developer only needs upload key
-- Upload key can be reset through Play Console if lost (unlike the app signing key)
-- The existing `build-with-secrets.ps1` pattern (injecting from a JSON file) could be extended for signing
+- The existing `build-with-secrets.ps1` pattern (injecting from a JSON file) is extended for signing
 - AAB format results in smaller downloads (Google generates optimized APKs per device)
-- Both APK (for testing) and AAB (for Play Store) builds may be needed
+- Both APK (for testing) and AAB (for Play Store) builds are needed
 
 ## Alternatives Considered
 
-Analysis deferred until decision criteria are evaluated by Product Owner.
+### Option A: Keystore in Local File with Environment Variables
+- **Description**: Store `.jks` on local disk, reference via `key.properties` (gitignored) and environment variables in `build.gradle.kts`. Follows Flutter's recommended approach.
+- **Pros**: Simple setup, well-documented by Flutter team
+- **Cons**: Keystore file persists on disk, `key.properties` could accidentally be committed despite gitignore
+- **Why Rejected**: Less secure than build-time injection; the project already uses a secrets injection pattern that avoids persistent credential files
+
+### Option C: GitHub Actions / CI-Based Signing
+- **Description**: Keystore stored as GitHub Actions secret (base64-encoded). Only CI produces release builds; local development uses debug keys.
+- **Pros**: Most secure (keystore never on developer machine), scalable for teams
+- **Cons**: No CI/CD pipeline exists yet, adds infrastructure dependency, cannot produce release builds locally
+- **Why Rejected**: Premature given current single-developer workflow and no CI/CD pipeline
 
 ## Consequences
 
-To be documented after decision is made.
+### Positive
+- Consistent with the existing secrets injection pattern (`build-with-secrets.ps1`), reducing cognitive overhead
+- Keystore never persists in the repository tree, eliminating accidental commit risk
+- Play App Signing enrollment adds a safety net (upload key can be reset if lost)
+- Supports future CI/CD integration (environment variables work in both local and CI contexts)
+
+### Negative
+- Build script complexity increases (must handle signing parameters in addition to secrets)
+- Keystore must be accessible to the build machine (secure backup strategy required)
+- Developer must remember to provide signing parameters for release builds
+
+### Neutral
+- Both APK and AAB build targets are needed (testing vs Play Store), adding two output formats to maintain
 
 ## References
 

--- a/docs/adr/0028-android-permission-strategy.md
+++ b/docs/adr/0028-android-permission-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -47,52 +47,63 @@ Google Play Store reviewers evaluate whether requested permissions are justified
 
 ## Decision
 
-**TO BE DETERMINED** - This ADR captures the decision criteria. The decision will be made by the Product Owner.
+**Option B: Full background support permissions.** Declare all permissions needed for reliable background scanning, including foreground service support.
 
-### Options Under Consideration
+### Permissions Declared in Main AndroidManifest.xml
 
-#### Option A: Minimal Permissions (Request Only What is Used)
-- INTERNET, POST_NOTIFICATIONS, RECEIVE_BOOT_COMPLETED, WAKE_LOCK
-- No foreground service permissions
-- Background scans may be killed by system on long scans
+| Permission | Type | API Level | Purpose |
+|------------|------|-----------|---------|
+| `INTERNET` | Normal | All | IMAP/Gmail API network access |
+| `POST_NOTIFICATIONS` | Dangerous | 33+ (Android 13+) | Background scan completion notifications |
+| `RECEIVE_BOOT_COMPLETED` | Normal | All | Re-schedule background scans after device restart |
+| `WAKE_LOCK` | Normal | All | Keep CPU awake during background scan execution |
+| `FOREGROUND_SERVICE` | Normal | 28+ (Android 9+) | Run long background scans without system kill |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Normal | 34+ (Android 14+) | Required foreground service type declaration |
 
-#### Option B: Full Background Support Permissions
-- All Option A permissions plus FOREGROUND_SERVICE, FOREGROUND_SERVICE_DATA_SYNC
-- Ensures background scans complete even for large mailboxes
-- More permissions to justify in Play Store review
+### Runtime Permission Strategy
 
-#### Option C: Progressive Permission Requests
-- Start with INTERNET only
-- Request POST_NOTIFICATIONS when user first enables background scanning
-- Request foreground service permissions only when needed
-- Most user-friendly but most complex to implement
-
-### Decision Criteria
-
-1. **User trust**: Fewer permissions = higher install rate
-2. **Functionality**: Background scans must complete reliably
-3. **Android version support**: Must work on API 26+ (Android 8+) through API 35+ (Android 15+)
-4. **Play Store compliance**: All permissions must be justified
-5. **User experience**: When and how to ask for runtime permissions
-6. **Graceful degradation**: App must work even if permissions are denied
+- `POST_NOTIFICATIONS` is the only dangerous permission (requires runtime request on Android 13+)
+- Request when user first enables background scanning in Settings
+- Show rationale dialog explaining why notifications are needed for scan results
+- Create notification channel BEFORE requesting permission
+- Handle denial gracefully: background scans work but complete silently without notifications
+- All other permissions are normal (auto-granted at install time)
 
 ### Key Points
 
-- `POST_NOTIFICATIONS` is the only dangerous permission needed (requires runtime request)
-- All other permissions are normal (auto-granted at install)
-- The notification channel must be created BEFORE requesting `POST_NOTIFICATIONS`
 - WorkManager handles background scheduling without exact alarm permissions
-- Foreground service may be needed for scans of large mailboxes (>500 emails) to prevent system kill
-- Android 14+ requires foreground service type declaration for ALL foreground services
-- The `workmanager` Flutter plugin may handle some permission requirements internally
+- `SCHEDULE_EXACT_ALARM` is NOT requested (inexact scheduling is acceptable for background scans)
+- Foreground service ensures scans of large mailboxes (>500 emails) complete without system kill
+- Android 14+ requires foreground service type declaration (`dataSync`) for all foreground services
 
 ## Alternatives Considered
 
-Analysis deferred until decision criteria are evaluated by Product Owner.
+### Option A: Minimal Permissions
+- **Description**: INTERNET, POST_NOTIFICATIONS, RECEIVE_BOOT_COMPLETED, WAKE_LOCK only. No foreground service permissions.
+- **Pros**: Fewest permissions to justify in Play Store review, highest user trust
+- **Cons**: Background scans may be killed by the system on large mailboxes without foreground service protection
+- **Why Rejected**: Reliability of background scanning is a core feature; users with large mailboxes would experience silent scan failures
+
+### Option C: Progressive Permission Requests
+- **Description**: Start with INTERNET only, request POST_NOTIFICATIONS when user enables background scanning, add foreground service permissions only when needed.
+- **Pros**: Most user-friendly, minimizes upfront permission requests
+- **Cons**: Most complex to implement, requires multiple permission request flows and state tracking
+- **Why Rejected**: Implementation complexity not justified for a single-developer project; can always refactor to progressive requests later if user feedback warrants it
 
 ## Consequences
 
-To be documented after decision is made.
+### Positive
+- Background scans complete reliably even for large mailboxes (foreground service prevents system kill)
+- All requested permissions are justified by actual app features (defensible in Play Store review)
+- Single runtime permission request (`POST_NOTIFICATIONS`) keeps UX simple
+
+### Negative
+- More permissions listed in Play Store than the minimal option, which may reduce install rate slightly
+- `POST_NOTIFICATIONS` requires a runtime request UX with rationale dialog (implementation effort)
+
+### Neutral
+- All permissions except `POST_NOTIFICATIONS` are normal (auto-granted), so the effective user-facing permission count is low
+- Foreground service type declaration (`dataSync`) is a standard Android 14+ requirement for background processing apps
 
 ## References
 

--- a/docs/adr/0030-privacy-and-data-governance-strategy.md
+++ b/docs/adr/0030-privacy-and-data-governance-strategy.md
@@ -159,6 +159,7 @@ Use an open-source privacy policy generator as the starting template, then custo
 - No crash reporting means production issues are harder to diagnose (users must report bugs manually)
 - Template-based privacy policy may not cover all edge cases (mitigated: can add legal review later)
 - Must maintain privacy policy page when app features change
+- **Browser target excluded**: The local-only processing model is incompatible with a browser (Flutter Web) target. IMAP protocol requires raw TCP sockets, which browsers block via the Same-Origin Policy. The only viable workaround -- a server-side IMAP proxy (the approach used by browser-based email clients such as Outlook Web) -- would route user credentials and email content through a backend server, violating this ADR's core principle. This constrains the app to native platforms only (desktop and mobile). Chromebook users are served by Android (Play Store) and Linux (Crostini) targets. See [ADR-0001](0001-flutter-dart-single-codebase.md) for platform scope.
 
 ### Neutral
 - Firebase Analytics dependency removal is a code task (GP-12 / ADR-0033)

--- a/docs/adr/0032-user-data-deletion-strategy.md
+++ b/docs/adr/0032-user-data-deletion-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -65,82 +65,101 @@ For Gmail OAuth connections specifically:
 
 ## Decision
 
-**TO BE DETERMINED** - This ADR captures the decision criteria. The decision will be made by the Product Owner.
+**Scope B + External A**: Per-account deletion plus full data wipe option. External deletion via GitHub Pages form on myemailspamfilter.com.
 
-### Options Under Consideration
+### In-App Deletion
 
-#### Deletion Scope
-
-##### Option A: Per-Account Deletion Only
-- Delete individual email provider connections and their data
-- Shared data (rules, safe senders) remains
+**Per-account deletion** (Settings > Account > "Remove Account"):
+- Deletes credentials, account settings, and scan results for the selected account
+- Shared data (rules, safe senders, app settings) is preserved
 - App continues to work for remaining accounts
-- Closest to what users expect ("remove this email account")
 
-##### Option B: Per-Account + Full Wipe Option
-- Per-account deletion (Option A) for individual accounts
-- Plus "Delete All Data" option that removes everything
+**Full data wipe** (Settings > Data Management > "Delete All Data"):
+- Removes all accounts, credentials, settings, rules, safe senders, and scan history
 - Resets app to fresh install state
-- Satisfies both per-account and full deletion use cases
+- Requires confirmation dialog (irreversible)
 
-##### Option C: Full App Data Wipe Only
-- Single "Delete All Data" button
-- Removes all accounts, settings, rules, safe senders
-- Simplest implementation
-- May frustrate users who only want to remove one account
+### Per-Account Deletion Steps
 
-#### External Deletion Mechanism
+1. Revoke OAuth tokens (Gmail: `https://oauth2.googleapis.com/revoke?token={token}`, IMAP: no API needed)
+2. Delete all credentials from flutter_secure_storage for the account (keys prefixed with account identifier)
+3. Delete `account_settings` rows matching `accountId` from SQLite
+4. Delete `scan_results` and `email_actions` rows matching `account_id` from SQLite
+5. Cancel background scan schedule for the account
+6. Remove platform-specific scheduled tasks (Windows Task Scheduler, Android WorkManager)
 
-##### Option A: GitHub Pages Form
-- Simple form on GitHub Pages site
-- User provides email address
-- Instructions to self-delete via app, or contact developer
-- Low cost, easy to maintain
+### Full Wipe Steps
 
-##### Option B: Dedicated Website with Deletion Form
-- Web form that accepts email and verification
-- Developer receives request and processes manually
-- More professional but requires manual processing
+1. Execute per-account deletion for all accounts
+2. Delete all rows from `rules`, `safe_senders`, `app_settings` tables
+3. Delete SQLite database file
+4. Clear all flutter_secure_storage entries
+5. Remove all platform-specific scheduled tasks
 
-##### Option C: Email-Based Request
-- Provide support email address
-- User emails to request deletion
-- Manual processing by developer
-- Simplest external mechanism but slowest response
+### External Deletion Mechanism
 
-##### Option D: In-App Self-Service Only (with Documentation)
-- Provide in-app deletion as primary mechanism
-- Website explains how to delete data via the app
-- Argue that since all data is local, uninstalling the app also deletes data
-- May not fully satisfy Google's requirement for external accessibility
-
-### Decision Criteria
-
-1. **Policy compliance**: Must satisfy Google Play account deletion requirement
-2. **User expectation**: Users expect "remove account" not "wipe everything"
-3. **Data safety**: Must not leave orphaned tokens or credentials
-4. **Implementation complexity**: Per-account deletion requires careful data isolation
-5. **External mechanism effort**: Website vs email vs GitHub Pages
-6. **Shared data handling**: Rules and safe senders are shared, not per-account
-7. **Reversibility**: Should deletion be confirmed and irreversible?
+- GitHub Pages form on myemailspamfilter.com
+- Explains that all data is stored locally on the user's device (no server-side data exists)
+- Instructs user to delete data via in-app mechanism or by uninstalling the app
+- Provides contact email for support requests
 
 ### Key Points
 
 - The app stores ALL data locally; there is no server-side data to delete
 - Uninstalling the app effectively deletes all data (but Google still requires in-app mechanism)
-- OAuth token revocation is important but may fail (token already expired, network issue)
-- Rules and safe senders are shared across accounts and should not be deleted when removing one account
+- OAuth token revocation may fail (network issues, token already expired) -- handle gracefully, do not block deletion
+- Rules and safe senders are shared across accounts and are NOT deleted during per-account deletion
 - Background scan tasks must be cleaned up when an account is deleted
-- The "external deletion" requirement can potentially be satisfied by documentation explaining that all data is local and can be deleted by removing the account in-app or uninstalling
 - flutter_secure_storage data persists across app reinstalls on some Android versions (linked to device encryption)
 
 ## Alternatives Considered
 
-Analysis deferred until decision criteria are evaluated by Product Owner.
+### Scope A: Per-Account Deletion Only
+- **Description**: Delete individual email provider connections and their data. No full wipe option.
+- **Pros**: Simpler implementation, closest to user expectation ("remove this email account")
+- **Cons**: No way to reset app to fresh install state without uninstalling
+- **Why Rejected**: Less complete; full wipe option adds minimal complexity and satisfies the "delete all data" use case
+
+### Scope C: Full App Data Wipe Only
+- **Description**: Single "Delete All Data" button that removes everything.
+- **Pros**: Simplest implementation
+- **Cons**: Frustrates users who only want to remove one email account; forces loss of rules and safe senders
+- **Why Rejected**: Users expect per-account removal, not all-or-nothing
+
+### External B: Dedicated Website with Deletion Form
+- **Description**: Web form that accepts email and verification, developer processes manually.
+- **Pros**: More professional appearance
+- **Cons**: Requires manual processing by developer, ongoing effort
+- **Why Rejected**: Overkill for a local-only app; all data is on the user's device
+
+### External C: Email-Based Request
+- **Description**: Provide support email, user emails to request deletion.
+- **Pros**: Simplest external mechanism
+- **Cons**: Slowest response time, manual processing
+- **Why Rejected**: Same as External B; manual processing not needed when all data is local
+
+### External D: In-App Self-Service Only
+- **Description**: In-app deletion as primary mechanism, website documents how to use it.
+- **Pros**: No external form needed
+- **Cons**: May not satisfy Google's requirement for external accessibility of deletion
+- **Why Rejected**: Risk of policy non-compliance; GitHub Pages form is low effort and removes ambiguity
 
 ## Consequences
 
-To be documented after decision is made.
+### Positive
+- Satisfies Google Play account deletion policy (both in-app and external mechanisms)
+- Per-account deletion preserves shared data (rules, safe senders), matching user expectations
+- Full wipe option available for users who want to reset completely
+- GitHub Pages form is low-cost and easy to maintain
+
+### Negative
+- Per-account deletion requires careful data isolation to avoid orphaned credentials or background tasks
+- GitHub Pages form needs maintenance (must stay accessible and accurate)
+- OAuth token revocation is best-effort (network failures handled gracefully, not blocking)
+
+### Neutral
+- Uninstalling the app also deletes all data, but the policy requires an explicit in-app mechanism regardless
+- flutter_secure_storage persistence across reinstalls on some Android versions means uninstall may not fully clear credentials on all devices
 
 ## References
 

--- a/docs/adr/0033-analytics-and-crash-reporting-strategy.md
+++ b/docs/adr/0033-analytics-and-crash-reporting-strategy.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -67,66 +67,67 @@ All Firebase data is sent to Google servers, which must be disclosed in privacy 
 
 ## Decision
 
-**TO BE DETERMINED** - This ADR captures the decision criteria. The decision will be made by the Product Owner.
+**Option A: Zero telemetry.** Remove all Firebase Analytics dependencies. No crash reporting, no analytics, no remote data collection of any kind. Keep `google-services.json` for Google Sign-In only.
 
-### Options Under Consideration
+### Implementation
 
-#### Option A: Remove All Firebase (Zero Telemetry)
-- Remove `firebase-bom` and `firebase-analytics` from `build.gradle.kts`
-- Keep `google-services.json` (still needed for Google Sign-In)
-- Simplest privacy disclosures
-- No production crash visibility
-- Align with app's privacy-focused positioning
+- Remove `firebase-analytics` from `build.gradle.kts` dependencies
+- Remove `firebase-bom` if no other Firebase services depend on it (verify before removing)
+- Keep `google-services.json` (required for Google Sign-In on Android)
+- Keep `apply plugin: 'com.google.gms.google-services'` (needed for `google-services.json` processing)
+- No Crashlytics, no analytics, no remote logging of any kind
 
-#### Option B: Firebase Crashlytics Only (Crash Reports)
-- Replace `firebase-analytics` with `firebase-crashlytics`
-- Add Crashlytics Dart SDK (`firebase_crashlytics`)
-- Initialize in `main.dart` with `FlutterError.onError` handler
-- Crash reports sent to Firebase Console
-- Must disclose in privacy policy and Data Safety form
-- Enables production issue detection
+### Debugging Strategy Without Remote Telemetry
 
-#### Option C: Firebase Crashlytics + Minimal Analytics
-- Crashlytics for crash reporting
-- Analytics for basic metrics (daily active users, screen views)
-- No custom event tracking
-- More useful for product decisions
-- More privacy disclosures required
-
-#### Option D: Opt-In Crash Reporting
-- Crashlytics included but disabled by default
-- User enables in Settings ("Help improve this app")
-- Most privacy-respectful approach
-- Fewer crash reports (most users leave defaults)
-- More complex implementation
-
-### Decision Criteria
-
-1. **Privacy alignment**: The app positions itself as privacy-focused (no backend, local processing)
-2. **Production visibility**: Can production issues be detected and fixed without crash reporting?
-3. **Privacy disclosure complexity**: Each data type collected adds privacy policy and Data Safety form complexity
-4. **CASA audit impact**: Auditors evaluate all data collection and transmission
-5. **User trust**: Privacy-conscious users may avoid apps with analytics
-6. **Development value**: How often are crash reports actually useful?
-7. **Google Sign-In dependency**: google-services.json is needed regardless of analytics decision
+- **Local logging**: AppLogger with keyword-based filtering (EMAIL, RULES, EVAL, DB, AUTH, SCAN, ERROR, PERF, UI, DEBUG)
+- **Background scan logs**: CSV-based debug logging to local file (Sprint 15)
+- **User-reported issues**: GitHub Issues and support email
+- **Development testing**: Debug builds with verbose console logging
 
 ### Key Points
 
 - The `google-services.json` file is needed for Google Sign-In on Android, independent of Firebase Analytics
 - Firebase Analytics can be removed without affecting Google Sign-In
-- If Firebase Analytics is kept in dependencies but never initialized, it should still be removed to avoid confusion during CASA audit
-- The current CSV-based background scan logging provides local debugging capability
-- User-reported issues (via email/GitHub) can partially substitute for crash reporting
-- The app's privacy-focused nature (no backend, no data sharing) is a competitive differentiator
-- Adding analytics could undermine the app's privacy messaging
+- Removing unused `firebase-analytics` dependency eliminates a code smell that would raise questions during CASA audit
+- The app's privacy-focused nature (no backend, no data sharing) is a competitive differentiator that would be undermined by analytics
 
 ## Alternatives Considered
 
-Analysis deferred until decision criteria are evaluated by Product Owner.
+### Option B: Firebase Crashlytics Only
+- **Description**: Replace `firebase-analytics` with `firebase-crashlytics`. Initialize in `main.dart` with `FlutterError.onError` handler. Crash reports sent to Firebase Console.
+- **Pros**: Enables production issue detection, low implementation effort
+- **Cons**: Requires privacy disclosures in privacy policy and Data Safety form, sends data to Google servers
+- **Why Rejected**: Undermines the app's privacy-focused positioning; privacy disclosures add complexity for minimal benefit at current scale
+
+### Option C: Firebase Crashlytics + Minimal Analytics
+- **Description**: Crashlytics for crash reporting plus basic analytics (daily active users, screen views, no custom events).
+- **Pros**: Most useful for product decisions (user counts, feature usage)
+- **Cons**: Most privacy disclosures required, sends the most data to Google servers
+- **Why Rejected**: Directly contradicts the app's local-only, no-telemetry messaging
+
+### Option D: Opt-In Crash Reporting
+- **Description**: Include Crashlytics but disabled by default. User enables in Settings ("Help improve this app").
+- **Pros**: Most privacy-respectful approach to crash reporting, user has control
+- **Cons**: Implementation complexity (Settings UI, consent management, conditional initialization), most users leave defaults so few crash reports received
+- **Why Rejected**: Implementation complexity not justified for minimal benefit; can be added later if user base grows and crash visibility becomes essential
 
 ## Consequences
 
-To be documented after decision is made.
+### Positive
+- Simplest possible privacy disclosures (no data collection to disclose)
+- Fully aligns with the app's privacy-focused competitive positioning
+- No CASA audit complications from analytics or crash reporting data
+- Smaller APK/AAB size without Firebase Analytics dependency
+- No dependency on Firebase Console for production monitoring
+
+### Negative
+- No remote visibility into production crashes (rely entirely on user reports via GitHub Issues and email)
+- Cannot proactively detect issues that users do not report
+- No usage metrics for product decisions (feature adoption, user counts)
+
+### Neutral
+- Can revisit this decision if user base grows and crash reporting becomes essential (Option D is a natural evolution path)
+- Current local logging infrastructure (AppLogger, CSV background scan logs) provides adequate debugging for development and local testing
 
 ## References
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,15 +31,15 @@ This directory contains Architectural Decision Records for the spamfilter-multi 
 | [0023](0023-in-memory-pattern-caching.md) | In-Memory Pattern Caching | Accepted | ~2025-10 |
 | [0024](0024-canonical-folder-mapping.md) | Canonical Folder Mapping | Accepted | ~2026-01 |
 | [0025](0025-changelog-per-commit-policy.md) | CHANGELOG Updated Per Commit Policy | Accepted | ~2026-01 |
-| [0026](0026-application-identity-and-package-naming.md) | Application Identity and Package Naming | Proposed | 2026-02-15 |
-| [0027](0027-android-release-signing-strategy.md) | Android Release Signing Strategy | Proposed | 2026-02-15 |
-| [0028](0028-android-permission-strategy.md) | Android Permission Strategy | Proposed | 2026-02-15 |
-| [0029](0029-gmail-api-scope-and-verification-strategy.md) | Gmail API Scope and Verification Strategy | Proposed | 2026-02-15 |
-| [0030](0030-privacy-and-data-governance-strategy.md) | Privacy and Data Governance Strategy | Proposed | 2026-02-15 |
-| [0031](0031-app-icon-and-visual-identity.md) | App Icon and Visual Identity | Proposed | 2026-02-15 |
-| [0032](0032-user-data-deletion-strategy.md) | User Data Deletion Strategy | Proposed | 2026-02-15 |
-| [0033](0033-analytics-and-crash-reporting-strategy.md) | Analytics and Crash Reporting Strategy | Proposed | 2026-02-15 |
-| [0034](0034-gmail-access-method-for-production.md) | Gmail Access Method for Production | Proposed | 2026-02-15 |
+| [0026](0026-application-identity-and-package-naming.md) | Application Identity and Package Naming | Accepted | 2026-02-15 |
+| [0027](0027-android-release-signing-strategy.md) | Android Release Signing Strategy | Accepted | 2026-02-15 |
+| [0028](0028-android-permission-strategy.md) | Android Permission Strategy | Accepted | 2026-02-15 |
+| [0029](0029-gmail-api-scope-and-verification-strategy.md) | Gmail API Scope and Verification Strategy | Accepted | 2026-02-15 |
+| [0030](0030-privacy-and-data-governance-strategy.md) | Privacy and Data Governance Strategy | Accepted | 2026-02-15 |
+| [0031](0031-app-icon-and-visual-identity.md) | App Icon and Visual Identity | Accepted | 2026-02-15 |
+| [0032](0032-user-data-deletion-strategy.md) | User Data Deletion Strategy | Accepted | 2026-02-15 |
+| [0033](0033-analytics-and-crash-reporting-strategy.md) | Analytics and Crash Reporting Strategy | Accepted | 2026-02-15 |
+| [0034](0034-gmail-access-method-for-production.md) | Gmail Access Method for Production | Accepted | 2026-02-15 |
 | [0035](0035-production-development-side-by-side.md) | Production and Development Builds Side-by-Side on Windows | Accepted | 2026-03-18 |
 | [0036](0036-msix-signing-strategy.md) | MSIX Signing Strategy for Windows Store Submission | Accepted | 2026-03-19 |
 

--- a/docs/sprints/SPRINT_29_RETROSPECTIVE.md
+++ b/docs/sprints/SPRINT_29_RETROSPECTIVE.md
@@ -1,0 +1,108 @@
+# Sprint 29 Retrospective
+
+**Sprint**: Sprint 29 - UX + Quality + Features
+**Date**: April 3-13, 2026
+**Branch**: `feature/20260403_Sprint_29`
+**PR**: #225
+
+---
+
+## Sprint Goal
+
+Improve UX (selectable text, scan history enhancements), add default rule set creation for new users, expand test coverage, and fix the pre-existing test failure.
+
+## Outcome: [OK] Complete
+
+All 4 planned tasks completed, plus testing feedback fixes and 5 new backlog items added.
+
+---
+
+## Tasks Completed
+
+| Task | Description | Status |
+|------|-------------|--------|
+| F50 | Make all page text selectable and copyable (21 screens) | [OK] Complete |
+| F48 | Scan History enhancements - multi-account, filters, totals | [OK] Complete |
+| F46 | Default rule set creation with reset option | [OK] Complete |
+| F42 | Test coverage gaps - 53 new tests | [OK] Complete |
+
+### Additional Work
+
+- Fixed pre-existing YAML round-trip test failure (rules path moved to assets/rules/)
+- Fixed 2 bugs in DefaultRuleSetService found by tests (dynamic typing, missing pattern_type)
+- Backlog refinement: removed 19 completed items and 4 detail sections from master plan
+- Added 5 backlog items: F52 (multi-variant install), F53 (.cc/.ne TLD blocks), F54 (Select Account icon), F55 (navigation consistency), F56 (manual rule creation UI)
+
+### Testing Feedback Fixes
+
+| Fix | Description | Status |
+|-----|-------------|--------|
+| F50 | Results screen + email detail popup SelectionArea | [OK] |
+| F50 | Account setup dialogs (AOL, Gmail, platform selection) SelectionArea | [OK] |
+| F48 | Account filter uses configured accounts, shows when >1 account | [OK] |
+| F48 | Left-align account filter, type filter, and totals rows | [OK] |
+| F48 | Remove redundant account selection dialog from Scan History nav | [OK] |
+| Misc | Manual Scan title shows account email instead of platform name | [OK] |
+
+---
+
+## Retrospective Feedback
+
+### User Feedback (All "Very Good")
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| Effective while Efficient | Very Good | |
+| Sprint Execution | Very Good | |
+| Testing Approach | Very Good | |
+| Effort Accuracy | Very Good | |
+| Planning Quality | Very Good | |
+| Model Assignments | Very Good | |
+| Communication | Very Good | |
+| Requirements Clarity | Very Good | |
+| Documentation | Very Good | |
+| Process Issues | Very Good | |
+| Risk Management | Very Good | |
+| Next Sprint Readiness | Very Good | |
+
+### User Minor Fix for Next Sprint
+
+- Reset Rules to Defaults (Settings > General): should include a popup suggesting YAML export as backup first, with user confirmation (yes/no)
+
+### Claude Feedback
+
+| Category | Rating | Notes |
+|----------|--------|-------|
+| Effective while Efficient | Very Good | Parallel agents for F50 (4 screen groups) and F42 (3 test files) saved significant time |
+| Sprint Execution | Very Good | All 4 tasks + testing feedback fixes completed autonomously after approval |
+| Testing Approach | Very Good | Tests found 2 real bugs in new DefaultRuleSetService code; fixed pre-existing failure |
+| Effort Accuracy | Good | Initial estimate ~22-28h; actual closer to ~18h for feature work, but testing feedback fixes added ~4h |
+| Planning Quality | Very Good | Backlog refinement before sprint planning set clear scope; all 4 candidates completed |
+| Model Assignments | Very Good | Haiku handled all tasks effectively; agents used for parallelizable work |
+| Communication | Very Good | Explained backlog refinement format error early; testing feedback analysis was thorough |
+| Requirements Clarity | Very Good | F46 clarification (Option A from both YAML files) resolved early |
+| Documentation | Very Good | CHANGELOG, master plan, and all backlog items kept current throughout |
+| Process Issues | Minor | Winwright MCP not connected in session -- could only do accessibility tree inspection, not interactive testing |
+| Risk Management | Good | SelectionArea wrapping approach was lower risk than individual SelectableText conversion |
+| Next Sprint Readiness | Very Good | 5 new backlog items defined; F53 ready as quick win for Sprint 30 |
+
+---
+
+## Improvements for Next Sprint
+
+| # | Improvement | Action |
+|---|------------|--------|
+| 1 | Reset to Defaults should suggest YAML export first | Add to Sprint 30 scope (minor fix from user feedback) |
+| 2 | Connect winwright MCP before sprint for interactive E2E testing | Verify winwright MCP server is in active MCP list at sprint start |
+| 3 | Test SelectionArea in dialogs during initial implementation | Dialogs are overlays outside parent SelectionArea -- test this pattern during F50-type work |
+
+---
+
+## Metrics
+
+- **Tests**: 1223 passing (+53 new), 28 skipped, 0 failures (was 1 pre-existing)
+- **Analyze**: 0 issues
+- **Commits**: 16
+- **Files changed**: 25+ across lib, test, and docs
+- **Issues addressed**: F50 (#220), F48 (#212), F46 (#208), F42 (#203)
+- **Backlog items added**: F52, F53, F54, F55, F56

--- a/docs/sprints/SPRINT_29_SUMMARY.md
+++ b/docs/sprints/SPRINT_29_SUMMARY.md
@@ -1,0 +1,33 @@
+# Sprint 29 Summary
+
+**Sprint**: Sprint 29 - UX + Quality + Features
+**Date**: April 3-13, 2026
+**Branch**: `feature/20260403_Sprint_29`
+**PR**: #225
+**Status**: [OK] Complete
+
+## What Was Done
+
+- **F50**: Added SelectionArea/SelectableText to all 21 screens, including dialogs and popups. Users can now select and copy text from any screen.
+- **F48**: Redesigned Scan History to show all accounts in one view with account filter chips, type filter chips, totals with tooltips, and retention days in title. Removed per-account navigation requirement.
+- **F46**: Created DefaultRuleSetService that seeds rules and safe senders from bundled YAML on fresh install. Added "Reset Rules to Defaults" button in Settings > General.
+- **F42**: Added 53 new tests (email_scanner: 20, default_rule_set_service: 11, yaml_service: 14, plus 8 fixed round-trip tests). Test failures reduced from 1 to 0.
+- **Testing feedback**: 6 fixes applied based on manual testing (results screen text selection, dialog text selection, account filter logic, totals alignment, scan history navigation, manual scan title).
+- **Backlog**: Added F52-F56 (multi-variant install, TLD blocks, Select Account icon, navigation consistency, manual rule creation UI).
+
+## Key Decisions
+
+- F46 scope: Extract from both rules.yaml and rules_safe_senders.yaml (Option A)
+- F48: Account filter based on configured accounts (credentials store), not scan data
+- F50: SelectionArea wrapping approach (not individual SelectableText) for broad coverage
+- AppBar titles not selectable: accepted as Flutter framework limitation
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Tests | 1223 passing, 28 skipped, 0 failures |
+| New tests | +53 |
+| Commits | 16 |
+| Screens updated | 21 (selectable text) |
+| Backlog items added | 5 (F52-F56) |

--- a/mobile-app/lib/core/providers/rule_set_provider.dart
+++ b/mobile-app/lib/core/providers/rule_set_provider.dart
@@ -11,6 +11,7 @@ import '../../adapters/storage/app_paths.dart';
 // LocalRuleStore import removed - YAML dual-write removed in Sprint 20
 import '../../core/models/rule_set.dart';
 import '../../core/models/safe_sender_list.dart';
+import '../../core/services/default_rule_set_service.dart';
 import '../../core/services/pattern_compiler.dart';
 import '../../core/storage/database_helper.dart';
 import '../../core/storage/migration_manager.dart';
@@ -134,7 +135,13 @@ class RuleSetProvider extends ChangeNotifier {
       _databaseStore = RuleDatabaseStore(databaseHelper);
       _safeSenderStore = SafeSenderDatabaseStore(databaseHelper);
 
-      // YAML dual-write removed in Sprint 20. DB is sole source of truth.
+      // Seed with default rules if database is empty (new install)
+      final defaultRuleSetService = DefaultRuleSetService(databaseHelper);
+      final seedResult = await defaultRuleSetService.seedIfEmpty();
+      if (seedResult.rules > 0 || seedResult.safeSenders > 0) {
+        _logger.i(
+            'Seeded ${seedResult.rules} default rules and ${seedResult.safeSenders} default safe senders');
+      }
 
       // Load rules and safe senders from database
       await loadRules();

--- a/mobile-app/lib/core/services/default_rule_set_service.dart
+++ b/mobile-app/lib/core/services/default_rule_set_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:logger/logger.dart';
+import 'package:sqflite/sqflite.dart';
 
 import '../storage/database_helper.dart';
 import 'yaml_service.dart';
@@ -62,14 +63,14 @@ class DefaultRuleSetService {
   }
 
   /// Load and seed rules and safe senders from bundled YAML assets.
-  Future<({int rules, int safeSenders})> _seedFromAssets(dynamic db) async {
-    return db.transaction((txn) async {
-      return _seedFromAssetsInTransaction(txn);
+  Future<({int rules, int safeSenders})> _seedFromAssets(Database db) async {
+    return await db.transaction((txn) async {
+      return await _seedFromAssetsInTransaction(txn);
     });
   }
 
   Future<({int rules, int safeSenders})> _seedFromAssetsInTransaction(
-      dynamic txn) async {
+      Transaction txn) async {
     int rulesSeeded = 0;
     int safeSendersSeeded = 0;
     final now = DateTime.now().millisecondsSinceEpoch;
@@ -141,6 +142,7 @@ class DefaultRuleSetService {
       for (final pattern in safeSenderList.safeSenders) {
         final dbSafeSender = {
           'pattern': pattern,
+          'pattern_type': _classifyPatternType(pattern),
           'date_added': now,
           'created_by': 'default',
         };
@@ -155,5 +157,26 @@ class DefaultRuleSetService {
     }
 
     return (rules: rulesSeeded, safeSenders: safeSendersSeeded);
+  }
+
+  /// Classify a safe sender pattern into its type.
+  ///
+  /// Mirrors SafeSenderList._determinePatternType logic.
+  static String _classifyPatternType(String pattern) {
+    if (pattern.contains(r'(?:') || pattern.contains(r'[a-z0-9-]+\.)*')) {
+      return 'entire_domain';
+    }
+    if (pattern.startsWith('^') && pattern.contains('@')) {
+      final beforeAt = pattern.substring(1).split('@')[0];
+      if (!beforeAt.startsWith('[') &&
+          !beforeAt.startsWith('(') &&
+          beforeAt.isNotEmpty) {
+        return 'exact_email';
+      }
+    }
+    if (pattern.contains('@') && !pattern.contains(r'[^@')) {
+      return 'exact_domain';
+    }
+    return 'exact_domain';
   }
 }

--- a/mobile-app/lib/core/services/default_rule_set_service.dart
+++ b/mobile-app/lib/core/services/default_rule_set_service.dart
@@ -1,0 +1,159 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:logger/logger.dart';
+
+import '../storage/database_helper.dart';
+import 'yaml_service.dart';
+
+/// Service for managing default rule set seeding and reset.
+///
+/// Reads the bundled YAML assets (rules.yaml and rules_safe_senders.yaml)
+/// and seeds the database with default rules and safe senders when the
+/// database is empty (new install) or on user request (reset to defaults).
+class DefaultRuleSetService {
+  final DatabaseHelper _dbHelper;
+  final Logger _logger = Logger();
+
+  static const String _rulesAssetPath = 'assets/rules/rules.yaml';
+  static const String _safeSendersAssetPath =
+      'assets/rules/rules_safe_senders.yaml';
+
+  DefaultRuleSetService(this._dbHelper);
+
+  /// Seed the database with default rules if it is empty.
+  ///
+  /// Called during app initialization after database is ready.
+  /// Only seeds if both rules and safe senders tables are empty.
+  /// Returns the number of rules and safe senders seeded.
+  Future<({int rules, int safeSenders})> seedIfEmpty() async {
+    final db = await _dbHelper.database;
+
+    final existingRules = await db.query('rules', limit: 1);
+    final existingSafeSenders = await db.query('safe_senders', limit: 1);
+
+    if (existingRules.isNotEmpty || existingSafeSenders.isNotEmpty) {
+      _logger.d('Database already has rules or safe senders, skipping seed');
+      return (rules: 0, safeSenders: 0);
+    }
+
+    _logger.i('Empty database detected, seeding with default rules');
+    return _seedFromAssets(db);
+  }
+
+  /// Reset the database to default rules and safe senders.
+  ///
+  /// Clears all existing rules and safe senders, then seeds from bundled
+  /// YAML assets. Returns the number of rules and safe senders seeded.
+  Future<({int rules, int safeSenders})> resetToDefaults() async {
+    final db = await _dbHelper.database;
+
+    _logger.i('Resetting rules and safe senders to defaults');
+
+    return db.transaction((txn) async {
+      // Clear existing data
+      await txn.delete('rules');
+      await txn.delete('safe_senders');
+      _logger.i('Cleared existing rules and safe senders');
+
+      // Seed from bundled assets within the same transaction
+      return _seedFromAssetsInTransaction(txn);
+    });
+  }
+
+  /// Load and seed rules and safe senders from bundled YAML assets.
+  Future<({int rules, int safeSenders})> _seedFromAssets(dynamic db) async {
+    return db.transaction((txn) async {
+      return _seedFromAssetsInTransaction(txn);
+    });
+  }
+
+  Future<({int rules, int safeSenders})> _seedFromAssetsInTransaction(
+      dynamic txn) async {
+    int rulesSeeded = 0;
+    int safeSendersSeeded = 0;
+    final now = DateTime.now().millisecondsSinceEpoch;
+
+    // Seed rules
+    try {
+      final rulesYaml = await rootBundle.loadString(_rulesAssetPath);
+      final yamlService = YamlService();
+      final ruleSet = yamlService.parseRulesFromString(rulesYaml);
+
+      for (final rule in ruleSet.rules) {
+        final dbRule = {
+          'name': rule.name,
+          'enabled': rule.enabled ? 1 : 0,
+          'is_local': rule.isLocal ? 1 : 0,
+          'execution_order': rule.executionOrder,
+          'condition_type': rule.conditions.type,
+          'condition_from': rule.conditions.from.isNotEmpty
+              ? jsonEncode(rule.conditions.from)
+              : null,
+          'condition_header': rule.conditions.header.isNotEmpty
+              ? jsonEncode(rule.conditions.header)
+              : null,
+          'condition_subject': rule.conditions.subject.isNotEmpty
+              ? jsonEncode(rule.conditions.subject)
+              : null,
+          'condition_body': rule.conditions.body.isNotEmpty
+              ? jsonEncode(rule.conditions.body)
+              : null,
+          'action_delete': rule.actions.delete ? 1 : 0,
+          'action_move_to_folder': rule.actions.moveToFolder,
+          'action_assign_category': rule.actions.assignToCategory,
+          'exception_from': rule.exceptions?.from.isNotEmpty ?? false
+              ? jsonEncode(rule.exceptions!.from)
+              : null,
+          'exception_header': rule.exceptions?.header.isNotEmpty ?? false
+              ? jsonEncode(rule.exceptions!.header)
+              : null,
+          'exception_subject': rule.exceptions?.subject.isNotEmpty ?? false
+              ? jsonEncode(rule.exceptions!.subject)
+              : null,
+          'exception_body': rule.exceptions?.body.isNotEmpty ?? false
+              ? jsonEncode(rule.exceptions!.body)
+              : null,
+          'metadata': rule.metadata != null ? jsonEncode(rule.metadata) : null,
+          'date_added': now,
+          'created_by': 'default',
+          'pattern_category': rule.patternCategory,
+          'pattern_sub_type': rule.patternSubType,
+          'source_domain': rule.sourceDomain,
+        };
+
+        await txn.insert('rules', dbRule);
+        rulesSeeded++;
+      }
+
+      _logger.i('Seeded $rulesSeeded default rules');
+    } catch (e) {
+      _logger.e('Failed to seed default rules', error: e);
+    }
+
+    // Seed safe senders
+    try {
+      final safeSendersYaml =
+          await rootBundle.loadString(_safeSendersAssetPath);
+      final yamlService = YamlService();
+      final safeSenderList = yamlService.parseSafeSendersFromString(safeSendersYaml);
+
+      for (final pattern in safeSenderList.safeSenders) {
+        final dbSafeSender = {
+          'pattern': pattern,
+          'date_added': now,
+          'created_by': 'default',
+        };
+
+        await txn.insert('safe_senders', dbSafeSender);
+        safeSendersSeeded++;
+      }
+
+      _logger.i('Seeded $safeSendersSeeded default safe senders');
+    } catch (e) {
+      _logger.e('Failed to seed default safe senders', error: e);
+    }
+
+    return (rules: rulesSeeded, safeSenders: safeSendersSeeded);
+  }
+}

--- a/mobile-app/lib/core/services/yaml_service.dart
+++ b/mobile-app/lib/core/services/yaml_service.dart
@@ -32,6 +32,19 @@ class YamlService {
     }
   }
 
+  /// Parse rules from a YAML string (no file I/O)
+  RuleSet parseRulesFromString(String yamlContent) {
+    final yaml = loadYaml(yamlContent);
+    final converted = _convertYamlToMap(yaml);
+    return RuleSet.fromMap(converted as Map<String, dynamic>);
+  }
+
+  /// Parse safe senders from a YAML string (no file I/O)
+  SafeSenderList parseSafeSendersFromString(String yamlContent) {
+    final yaml = loadYaml(yamlContent) as Map;
+    return SafeSenderList.fromMap(Map<String, dynamic>.from(yaml));
+  }
+
   /// Load safe senders from YAML file
   Future<SafeSenderList> loadSafeSenders(String filePath) async {
     final file = File(filePath);

--- a/mobile-app/lib/ui/screens/account_maintenance_screen.dart
+++ b/mobile-app/lib/ui/screens/account_maintenance_screen.dart
@@ -404,7 +404,8 @@ class _AccountMaintenanceScreenState extends State<AccountMaintenanceScreen> {
         title: const Text('Account Maintenance'),
         elevation: 0,
       ),
-      body: _isLoading
+      body: SelectionArea(
+        child: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _accounts.isEmpty
               ? Center(
@@ -441,6 +442,7 @@ class _AccountMaintenanceScreenState extends State<AccountMaintenanceScreen> {
                   separatorBuilder: (_, __) => const Divider(),
                   itemBuilder: (_, index) => _buildAccountTile(_accounts[index]),
                 ),
+      ),
     );
   }
 

--- a/mobile-app/lib/ui/screens/account_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/account_selection_screen.dart
@@ -482,35 +482,14 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
     );
   }
 
-  /// Navigate to scan history with account selection
-  /// [NEW] ISSUE #219: Reuses shared account selection dialog
-  void _openScanHistory() async {
-    if (_savedAccounts.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please add an email account first')),
-      );
-      return;
-    }
-
-    final selected = await _showAccountSelectionDialog();
-
-    if (selected != null && mounted) {
-      final displayData = _accountDataCache[selected];
-      final email = displayData?.email ?? selected;
-      final platformId = displayData?.platformId ?? '';
-
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (_) => ScanHistoryScreen(
-            accountId: selected,
-            accountEmail: email,
-            platformId: platformId,
-            platformDisplayName: _getPlatformDisplayName(platformId),
-          ),
-        ),
-      );
-    }
+  /// Navigate to scan history (shows all accounts with filter chips)
+  void _openScanHistory() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => const ScanHistoryScreen(),
+      ),
+    );
   }
 
   /// Delete account with confirmation dialog

--- a/mobile-app/lib/ui/screens/account_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/account_selection_screen.dart
@@ -636,10 +636,11 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
         elevation: 2,
         actions: [_buildHistoryButton(), _buildSettingsButton()],
       ),
-      body: Column(
-        children: [
-          // Header section
-          Container(
+      body: SelectionArea(
+        child: Column(
+          children: [
+            // Header section
+            Container(
             width: double.infinity,
             padding: const EdgeInsets.all(16),
             color: Theme.of(context).colorScheme.surface,
@@ -771,7 +772,8 @@ class _AccountSelectionScreenState extends State<AccountSelectionScreen> with Wi
               },
             ),
           ),
-        ],
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: _addNewAccount,

--- a/mobile-app/lib/ui/screens/account_setup_screen.dart
+++ b/mobile-app/lib/ui/screens/account_setup_screen.dart
@@ -296,13 +296,14 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
       appBar: AppBar(
         title: const Text('Gmail - Sign In Method'),
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const Text(
-              'How would you like to sign in to Gmail?',
+      body: SelectionArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Text(
+                'How would you like to sign in to Gmail?',
               style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
@@ -370,7 +371,8 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
                 ],
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -482,13 +484,14 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
               )
             : null,
       ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-              '${_effectiveDisplayName} Email Setup',
+      body: SelectionArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                '${_effectiveDisplayName} Email Setup',
               style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
             ),
 
@@ -646,7 +649,8 @@ class _AccountSetupScreenState extends State<AccountSetupScreen> {
               style: const TextStyle(color: Colors.grey, fontSize: 12),
               textAlign: TextAlign.center,
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -946,11 +950,13 @@ class _ScanModeSelectorState extends State<_ScanModeSelector> {
               Text('Warning: Full Scan Mode'),
             ],
           ),
-          content: const Text(
-            'Full Scan mode will PERMANENTLY delete or move emails based on your rules.\n\n'
-            'This action CANNOT be undone.\n\n'
-            'Are you sure you want to enable Full Scan mode?',
-            style: TextStyle(fontSize: 14),
+          content: SelectionArea(
+            child: const Text(
+              'Full Scan mode will PERMANENTLY delete or move emails based on your rules.\n\n'
+              'This action CANNOT be undone.\n\n'
+              'Are you sure you want to enable Full Scan mode?',
+              style: TextStyle(fontSize: 14),
+            ),
           ),
           actions: [
             TextButton(
@@ -1022,11 +1028,12 @@ class _ScanModeSelectorState extends State<_ScanModeSelector> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Scan Mode'),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+      content: SelectionArea(
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
             const Text(
               'How would you like to scan emails?',
               style: TextStyle(fontWeight: FontWeight.bold),
@@ -1307,7 +1314,8 @@ class _ScanModeSelectorState extends State<_ScanModeSelector> {
                 ],
               ),
             ),
-          ],
+            ],
+          ),
         ),
       ),
       actions: [

--- a/mobile-app/lib/ui/screens/background_scan_log_screen.dart
+++ b/mobile-app/lib/ui/screens/background_scan_log_screen.dart
@@ -85,7 +85,7 @@ class _BackgroundScanLogScreenState extends State<BackgroundScanLogScreen> {
       ),
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
-          : _buildBody(),
+          : SelectionArea(child: _buildBody()),
     );
   }
 

--- a/mobile-app/lib/ui/screens/background_scan_progress_screen.dart
+++ b/mobile-app/lib/ui/screens/background_scan_progress_screen.dart
@@ -17,7 +17,8 @@ class BackgroundScanProgressScreen extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.grey[100],
-      body: Center(
+      body: SelectionArea(
+        child: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -58,6 +59,7 @@ class BackgroundScanProgressScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }

--- a/mobile-app/lib/ui/screens/email_detail_view.dart
+++ b/mobile-app/lib/ui/screens/email_detail_view.dart
@@ -707,7 +707,7 @@ class _EmailDetailViewState extends State<EmailDetailView>
                     style: Theme.of(context).textTheme.labelSmall,
                   ),
                   const SizedBox(height: 4),
-                  Text(
+                  SelectableText(
                     (widget.email.subject?.isNotEmpty ?? false)
                         ? widget.email.subject!
                         : '(No subject)',
@@ -722,19 +722,19 @@ class _EmailDetailViewState extends State<EmailDetailView>
                     style: Theme.of(context).textTheme.labelSmall,
                   ),
                   const SizedBox(height: 4),
-                  Text(
+                  SelectableText(
                     widget.email.fromEmail,
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   if (widget.email.fromName != null &&
                       widget.email.fromName!.isNotEmpty)
-                    Text(
+                    SelectableText(
                       widget.email.fromName!,
                       style: Theme.of(context).textTheme.bodySmall,
                     ),
                   if (_senderDomain != null) ...[
                     const SizedBox(height: 4),
-                    Text(
+                    SelectableText(
                       'Domain: $_senderDomain',
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                             color: Colors.grey[600],
@@ -755,7 +755,7 @@ class _EmailDetailViewState extends State<EmailDetailView>
                               'Folder',
                               style: Theme.of(context).textTheme.labelSmall,
                             ),
-                            Text(
+                            SelectableText(
                               widget.email.folderName,
                               style: Theme.of(context).textTheme.bodySmall,
                             ),
@@ -770,7 +770,7 @@ class _EmailDetailViewState extends State<EmailDetailView>
                               'Date',
                               style: Theme.of(context).textTheme.labelSmall,
                             ),
-                            Text(
+                            SelectableText(
                               widget.email.emailDate != null
                                   ? widget.email.emailDate!
                                       .toString()

--- a/mobile-app/lib/ui/screens/folder_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/folder_selection_screen.dart
@@ -378,7 +378,7 @@ class _FolderSelectionScreenState extends State<FolderSelectionScreen> {
           ),
         ],
       ),
-      body: Column(
+      body: SelectionArea(child: Column(
         children: [
           // Account info
           Container(
@@ -628,7 +628,7 @@ class _FolderSelectionScreenState extends State<FolderSelectionScreen> {
               ),
             ),
         ],
-      ),
+      )),
     );
   }
 }

--- a/mobile-app/lib/ui/screens/gmail_oauth_screen.dart
+++ b/mobile-app/lib/ui/screens/gmail_oauth_screen.dart
@@ -52,13 +52,14 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
       barrierDismissible: false,
       builder: (context) => AlertDialog(
         title: const Text('Choose Authentication Method'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                'Gmail OAuth on Windows requires one of these methods:',
+        content: SelectionArea(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Gmail OAuth on Windows requires one of these methods:',
                 style: TextStyle(fontWeight: FontWeight.w500),
               ),
               const SizedBox(height: 16),
@@ -94,7 +95,8 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
                   _handleManualTokenEntry();
                 },
               ),
-            ],
+              ],
+            ),
           ),
         ),
         actions: [
@@ -124,13 +126,14 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
       barrierDismissible: false,
       builder: (context) => AlertDialog(
         title: const Text('Alternate Sign-In Methods'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const Text(
-                'If Google Sign-In is unresponsive in this emulator, try one of these:',
+        content: SelectionArea(
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'If Google Sign-In is unresponsive in this emulator, try one of these:',
                 style: TextStyle(fontWeight: FontWeight.w500),
               ),
               const SizedBox(height: 16),
@@ -155,7 +158,8 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
                   _handleManualTokenEntry();
                 },
               ),
-            ],
+              ],
+            ),
           ),
         ),
         actions: [

--- a/mobile-app/lib/ui/screens/gmail_oauth_screen.dart
+++ b/mobile-app/lib/ui/screens/gmail_oauth_screen.dart
@@ -437,10 +437,11 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
         title: const Text('Gmail Sign-In'),
         elevation: 0,
       ),
-      body: SingleChildScrollView(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
+      body: SelectionArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
             mainAxisAlignment: MainAxisAlignment.start,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -579,6 +580,7 @@ class _GmailOAuthScreenState extends State<GmailOAuthScreen> {
               // Privacy notice
               _buildPrivacyNotice(context),
             ],
+          ),
           ),
         ),
       ),

--- a/mobile-app/lib/ui/screens/main_navigation_screen.dart
+++ b/mobile-app/lib/ui/screens/main_navigation_screen.dart
@@ -102,27 +102,29 @@ class _PlaceholderScreen extends StatelessWidget {
       appBar: AppBarWithExit(
         title: Text(title),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              icon,
-              size: 64,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
-            ),
-            const SizedBox(height: 24),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 32),
-              child: Text(
-                message,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-                    ),
+      body: SelectionArea(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                icon,
+                size: 64,
+                color: Theme.of(context).colorScheme.primary.withOpacity(0.5),
               ),
-            ),
-          ],
+              const SizedBox(height: 24),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Text(
+                  message,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                      ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile-app/lib/ui/screens/platform_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/platform_selection_screen.dart
@@ -78,73 +78,75 @@ class _PlatformSelectionScreenState extends State<PlatformSelectionScreen> {
         title: const Text('Select Email Provider'),
         elevation: 0,
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Header section with introduction
-            Container(
-              color: Theme.of(context).colorScheme.surface,
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Choose Your Email Provider',
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Select your email provider to get started with spam filtering',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Colors.grey[600],
-                        ),
-                  ),
-                  const SizedBox(height: 16),
-                  // [UPDATED] Sprint 19: Demo Mode as direct-launch card
-                  Card(
-                    color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                    child: ListTile(
-                      leading: Icon(Icons.science_outlined, color: Colors.purple.shade400),
-                      title: const Text('Try Demo Mode'),
-                      subtitle: const Text('Test with 50+ sample emails (no email account needed)'),
-                      trailing: const Icon(Icons.arrow_forward_ios, size: 16),
-                      onTap: _startDemoMode,
+      body: SelectionArea(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Header section with introduction
+              Container(
+                color: Theme.of(context).colorScheme.surface,
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Choose Your Email Provider',
+                      style: Theme.of(context).textTheme.headlineSmall,
                     ),
-                  ),
-                ],
+                    const SizedBox(height: 8),
+                    Text(
+                      'Select your email provider to get started with spam filtering',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    const SizedBox(height: 16),
+                    // [UPDATED] Sprint 19: Demo Mode as direct-launch card
+                    Card(
+                      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                      child: ListTile(
+                        leading: Icon(Icons.science_outlined, color: Colors.purple.shade400),
+                        title: const Text('Try Demo Mode'),
+                        subtitle: const Text('Test with 50+ sample emails (no email account needed)'),
+                        trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+                        onTap: _startDemoMode,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
 
-            // Platform cards section
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                children: [
-                  // Phase 1 - MVP platforms
-                  _buildPhaseHeader('Available Now', 1),
-                  const SizedBox(height: 12),
-                  ...platforms
-                      .where((p) => p.phase == 1)
-                      .map((p) => _buildPlatformCard(p))
-                      .toList(),
+              // Platform cards section
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  children: [
+                    // Phase 1 - MVP platforms
+                    _buildPhaseHeader('Available Now', 1),
+                    const SizedBox(height: 12),
+                    ...platforms
+                        .where((p) => p.phase == 1)
+                        .map((p) => _buildPlatformCard(p))
+                        .toList(),
 
-                  // Phase 2 platforms
-                  const SizedBox(height: 24),
-                  _buildPhaseHeader('Coming Soon', 2),
-                  const SizedBox(height: 12),
-                  ...platforms
-                      .where((p) => p.phase == 2)
-                      .map((p) => _buildPlatformCard(p))
-                      .toList(),
+                    // Phase 2 platforms
+                    const SizedBox(height: 24),
+                    _buildPhaseHeader('Coming Soon', 2),
+                    const SizedBox(height: 12),
+                    ...platforms
+                        .where((p) => p.phase == 2)
+                        .map((p) => _buildPlatformCard(p))
+                        .toList(),
 
-                  // Info section
-                  const SizedBox(height: 32),
-                  _buildInfoCard(),
-                ],
+                    // Info section
+                    const SizedBox(height: 32),
+                    _buildInfoCard(),
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/mobile-app/lib/ui/screens/platform_selection_screen.dart
+++ b/mobile-app/lib/ui/screens/platform_selection_screen.dart
@@ -325,9 +325,11 @@ class _PlatformSelectionScreenState extends State<PlatformSelectionScreen> {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Coming Soon'),
-        content: Text(
-          '${platformInfo.displayName} support is planned for Phase 2.\n\n'
-          'For now, you can use ${platformInfo.displayName} via our generic IMAP support if you have an app password available.',
+        content: SelectionArea(
+          child: Text(
+            '${platformInfo.displayName} support is planned for Phase 2.\n\n'
+            'For now, you can use ${platformInfo.displayName} via our generic IMAP support if you have an app password available.',
+          ),
         ),
         actions: [
           TextButton(
@@ -417,13 +419,14 @@ class _SetupInstructionsDialogState extends State<_SetupInstructionsDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text('${widget.platformInfo.displayName} Setup'),
-      content: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              'Before connecting, you\'ll need to generate an app password:',
+      content: SelectionArea(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Before connecting, you\'ll need to generate an app password:',
               style: Theme.of(context).textTheme.bodyMedium,
             ),
             const SizedBox(height: 16),
@@ -458,7 +461,8 @@ class _SetupInstructionsDialogState extends State<_SetupInstructionsDialog> {
                   ],
                 ),
               ),
-          ],
+            ],
+          ),
         ),
       ),
       actions: [

--- a/mobile-app/lib/ui/screens/process_results_screen.dart
+++ b/mobile-app/lib/ui/screens/process_results_screen.dart
@@ -160,7 +160,8 @@ class _ProcessResultsScreenState extends State<ProcessResultsScreen> {
         title: Text('Unmatched Emails - ${widget.accountEmail}'),
         elevation: 0,
       ),
-      body: FutureBuilder<ScanResult?>(
+      body: SelectionArea(
+        child: FutureBuilder<ScanResult?>(
         future: _scanResultFuture,
         builder: (context, scanSnapshot) {
           if (scanSnapshot.connectionState == ConnectionState.waiting) {
@@ -290,6 +291,7 @@ class _ProcessResultsScreenState extends State<ProcessResultsScreen> {
             },
           );
         },
+      ),
       ),
     );
   }

--- a/mobile-app/lib/ui/screens/results_display_screen.dart
+++ b/mobile-app/lib/ui/screens/results_display_screen.dart
@@ -567,7 +567,8 @@ class _ResultsDisplayScreenState extends State<ResultsDisplayScreen> {
           ],
         ],
       ),
-      body: Padding(
+      body: SelectionArea(
+        child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -684,6 +685,7 @@ class _ResultsDisplayScreenState extends State<ResultsDisplayScreen> {
           ],
         ),
       ),
+      ), // Close SelectionArea
     ),
     ); // Close Focus widget for Issue 2: Ctrl+F shortcut
   }
@@ -1333,7 +1335,8 @@ class _ResultsDisplayScreenState extends State<ResultsDisplayScreen> {
               child: Material(
                 elevation: 8,
                 borderRadius: BorderRadius.circular(12),
-                child: SingleChildScrollView(
+                child: SelectionArea(
+                  child: SingleChildScrollView(
                   child: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
@@ -1577,6 +1580,7 @@ class _ResultsDisplayScreenState extends State<ResultsDisplayScreen> {
             ),
           ),
                 ),
+              ), // Close SelectionArea
               ),
             ),
           ],

--- a/mobile-app/lib/ui/screens/rule_quick_add_screen.dart
+++ b/mobile-app/lib/ui/screens/rule_quick_add_screen.dart
@@ -432,7 +432,8 @@ class _RuleQuickAddScreenState extends State<RuleQuickAddScreen> {
       ),
       body: Form(
         key: _formKey,
-        child: SingleChildScrollView(
+        child: SelectionArea(
+          child: SingleChildScrollView(
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -452,6 +453,7 @@ class _RuleQuickAddScreenState extends State<RuleQuickAddScreen> {
               _buildActionButtons(),
             ],
           ),
+        ),
         ),
       ),
     );

--- a/mobile-app/lib/ui/screens/rule_test_screen.dart
+++ b/mobile-app/lib/ui/screens/rule_test_screen.dart
@@ -192,7 +192,7 @@ class _RuleTestScreenState extends State<RuleTestScreen> {
       appBar: AppBar(
         title: const Text('Test Rule Pattern'),
       ),
-      body: Column(
+      body: SelectionArea(child: Column(
         children: [
           // Pattern input area
           _buildPatternInput(),
@@ -204,7 +204,7 @@ class _RuleTestScreenState extends State<RuleTestScreen> {
                 : _buildResults(),
           ),
         ],
-      ),
+      )),
     );
   }
 

--- a/mobile-app/lib/ui/screens/safe_senders_management_screen.dart
+++ b/mobile-app/lib/ui/screens/safe_senders_management_screen.dart
@@ -330,7 +330,8 @@ class _SafeSendersManagementScreenState
           ),
         ],
       ),
-      body: Column(
+      body: SelectionArea(
+        child: Column(
         children: [
           // Search bar
           Padding(
@@ -459,6 +460,7 @@ class _SafeSendersManagementScreenState
                       ),
           ),
         ],
+      ),
       ),
     );
   }

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -169,10 +169,12 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   Widget _buildAccountFilter() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
             _buildAccountChip('All Accounts', 'all'),
             const SizedBox(width: 8),
             ..._distinctAccounts.map((accountId) {
@@ -184,6 +186,7 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
             }),
           ],
         ),
+      ),
       ),
     );
   }
@@ -205,14 +208,18 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   Widget _buildTypeFilter() {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
-        children: [
-          _buildFilterChip('All', 'all'),
-          const SizedBox(width: 8),
-          _buildFilterChip('Manual', 'manual'),
-          const SizedBox(width: 8),
-          _buildFilterChip('Background', 'background'),
-        ],
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildFilterChip('All', 'all'),
+            const SizedBox(width: 8),
+            _buildFilterChip('Manual', 'manual'),
+            const SizedBox(width: 8),
+            _buildFilterChip('Background', 'background'),
+          ],
+        ),
       ),
     );
   }
@@ -257,6 +264,7 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
       child: Wrap(
+        alignment: WrapAlignment.start,
         spacing: 8,
         runSpacing: 8,
         children: [

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -263,10 +263,12 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: Wrap(
-        alignment: WrapAlignment.start,
-        spacing: 8,
-        runSpacing: 8,
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Wrap(
+          alignment: WrapAlignment.start,
+          spacing: 8,
+          runSpacing: 8,
         children: [
           _buildTotalChip('Total', totalEmails, Colors.blue,
               'Total unique emails found'),
@@ -283,6 +285,7 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
           _buildTotalChip('Errors', totalErrors, Colors.red.shade300,
               'Total unique emails not processed due to errors'),
         ],
+      ),
       ),
     );
   }

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -111,7 +111,7 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
       ),
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
-          : _buildBody(),
+          : SelectionArea(child: _buildBody()),
     );
   }
 

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -10,15 +10,15 @@ import 'results_display_screen.dart';
 
 /// Unified scan history screen showing both manual and background scans
 ///
-/// Replaces the separate BackgroundScanLogScreen with a consolidated view
-/// that shows all scan types in a single chronological list. Users can
-/// filter by scan type (manual/background/all) and tap entries to view
-/// detailed results.
+/// Shows all accounts in a single chronological list with account and type
+/// filters. Users can filter by account and scan type, view totals with
+/// tooltips, and tap entries to view detailed results.
 class ScanHistoryScreen extends StatefulWidget {
   final String? accountId;
   final String? accountEmail;
   final String? platformId;
   final String? platformDisplayName;
+  final String? preSelectedAccountId;
 
   const ScanHistoryScreen({
     super.key,
@@ -26,6 +26,7 @@ class ScanHistoryScreen extends StatefulWidget {
     this.accountEmail,
     this.platformId,
     this.platformDisplayName,
+    this.preSelectedAccountId,
   });
 
   @override
@@ -42,12 +43,19 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   List<ScanResult> _filteredScans = [];
   bool _isLoading = true;
   String _typeFilter = 'all'; // 'all', 'manual', 'background'
+  String _accountFilter = 'all'; // 'all' or specific accountId
   int _retentionDays = SettingsStore.defaultScanHistoryRetentionDays;
+  List<String> _distinctAccounts = []; // unique accountIds from scan data
+  Map<String, String> _accountEmails = {}; // accountId -> email display
 
   @override
   void initState() {
     super.initState();
     _scanResultStore = ScanResultStore(_dbHelper);
+    // Pre-select account filter if navigating from Settings
+    if (widget.preSelectedAccountId != null) {
+      _accountFilter = widget.preSelectedAccountId!;
+    }
     _loadHistory();
   }
 
@@ -60,14 +68,33 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
       // Auto-purge old entries
       await _scanResultStore.purgeOldScanResults(_retentionDays);
 
-      // Load scan history filtered by account when available
-      final scans = widget.accountId != null
-          ? await _scanResultStore.getScanResultsByAccount(widget.accountId!)
-          : await _scanResultStore.getAllScanHistory(limit: 200);
+      // Always load all scans across all accounts
+      final scans = await _scanResultStore.getAllScanHistory(limit: 500);
+
+      // Extract distinct accounts from scan data
+      final accountIds = <String>{};
+      for (final scan in scans) {
+        accountIds.add(scan.accountId);
+      }
+      final sortedAccounts = accountIds.toList()..sort();
+
+      // Build email display map from accountId
+      // accountId format is "{platform}-{email}"
+      final emailMap = <String, String>{};
+      for (final accountId in sortedAccounts) {
+        final dashIndex = accountId.indexOf('-');
+        if (dashIndex > 0 && dashIndex < accountId.length - 1) {
+          emailMap[accountId] = accountId.substring(dashIndex + 1);
+        } else {
+          emailMap[accountId] = accountId;
+        }
+      }
 
       if (mounted) {
         setState(() {
           _allScans = scans;
+          _distinctAccounts = sortedAccounts;
+          _accountEmails = emailMap;
           _applyFilter();
           _isLoading = false;
         });
@@ -84,23 +111,26 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   }
 
   void _applyFilter() {
-    if (_typeFilter == 'all') {
-      _filteredScans = List.from(_allScans);
-    } else {
-      _filteredScans = _allScans
-          .where((s) => s.scanType == _typeFilter)
-          .toList();
+    var scans = List<ScanResult>.from(_allScans);
+
+    // Apply account filter
+    if (_accountFilter != 'all') {
+      scans = scans.where((s) => s.accountId == _accountFilter).toList();
     }
+
+    // Apply type filter
+    if (_typeFilter != 'all') {
+      scans = scans.where((s) => s.scanType == _typeFilter).toList();
+    }
+
+    _filteredScans = scans;
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBarWithExit(
-        // [UPDATED] ISSUE #219: Show account email in title when filtered
-        title: Text(widget.accountEmail != null
-            ? 'Scan History - ${widget.accountEmail}'
-            : 'Scan History'),
+        title: Text('Scan History ($_retentionDays days)'),
         actions: [
           IconButton(
             icon: const Icon(Icons.refresh),
@@ -118,13 +148,13 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   Widget _buildBody() {
     return Column(
       children: [
+        // Account filter chips (only show if multiple accounts)
+        if (_distinctAccounts.length > 1) _buildAccountFilter(),
         // Type filter chips
         _buildTypeFilter(),
-        // Summary stats
-        _buildSummaryStats(),
+        // Summary totals
+        _buildTotals(),
         const Divider(),
-        // Retention info
-        _buildRetentionInfo(),
         // Scan list
         Expanded(
           child: _filteredScans.isEmpty
@@ -132,6 +162,42 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
               : _buildScanList(),
         ),
       ],
+    );
+  }
+
+  Widget _buildAccountFilter() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            _buildAccountChip('All Accounts', 'all'),
+            const SizedBox(width: 8),
+            ..._distinctAccounts.map((accountId) {
+              final email = _accountEmails[accountId] ?? accountId;
+              return Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: _buildAccountChip(email, accountId),
+              );
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAccountChip(String label, String value) {
+    final isSelected = _accountFilter == value;
+    return FilterChip(
+      label: Text(label, overflow: TextOverflow.ellipsis),
+      selected: isSelected,
+      onSelected: (selected) {
+        setState(() {
+          _accountFilter = value;
+          _applyFilter();
+        });
+      },
     );
   }
 
@@ -164,12 +230,27 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
     );
   }
 
-  Widget _buildSummaryStats() {
-    final total = _filteredScans.length;
-    final completed = _filteredScans.where((s) => s.status == 'completed').length;
-    final errors = _filteredScans.where((s) => s.status == 'error').length;
+  Widget _buildTotals() {
+    final totalEmails = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.totalEmails,
+    );
     final totalProcessed = _filteredScans.fold<int>(
       0, (sum, s) => sum + s.processedCount,
+    );
+    final totalDeleted = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.deletedCount,
+    );
+    final totalMoved = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.movedCount,
+    );
+    final totalSafe = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.safeSenderCount,
+    );
+    final totalNoRule = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.noRuleCount,
+    );
+    final totalErrors = _filteredScans.fold<int>(
+      0, (sum, s) => sum + s.errorCount,
     );
 
     return Padding(
@@ -178,34 +259,37 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
         spacing: 8,
         runSpacing: 8,
         children: [
-          _buildStatChip('Total', total, Colors.blue),
-          _buildStatChip('Completed', completed, Colors.green),
-          if (errors > 0) _buildStatChip('Errors', errors, Colors.red),
-          _buildStatChip('Emails Processed', totalProcessed, Colors.purple),
+          _buildTotalChip('Total', totalEmails, Colors.blue,
+              'Total unique emails found'),
+          _buildTotalChip('Processed', totalProcessed, Colors.purple,
+              'Total emails processed'),
+          _buildTotalChip('Deleted', totalDeleted, Colors.red,
+              'Total unique emails deleted'),
+          _buildTotalChip('Moved', totalMoved, Colors.orange,
+              'Total unique emails moved'),
+          _buildTotalChip('Safe', totalSafe, Colors.green,
+              'Total unique emails marked safe (not including Safe Folder)'),
+          _buildTotalChip('No Rule', totalNoRule, Colors.grey,
+              'Total unique emails currently with no rules assigned'),
+          _buildTotalChip('Errors', totalErrors, Colors.red.shade300,
+              'Total unique emails not processed due to errors'),
         ],
       ),
     );
   }
 
-  Widget _buildStatChip(String label, int value, Color color) {
-    return Chip(
-      label: Text('$label: $value'),
-      backgroundColor: color.withOpacity(0.15),
-      labelStyle: TextStyle(
-        color: _darkenColor(color),
-        fontWeight: FontWeight.w600,
-        fontSize: 12,
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
-    );
-  }
-
-  Widget _buildRetentionInfo() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: Text(
-        'Showing history for the last $_retentionDays days',
-        style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+  Widget _buildTotalChip(String label, int value, Color color, String tooltip) {
+    return Tooltip(
+      message: tooltip,
+      child: Chip(
+        label: Text('$label: $value'),
+        backgroundColor: color.withOpacity(0.15),
+        labelStyle: TextStyle(
+          color: _darkenColor(color),
+          fontWeight: FontWeight.w600,
+          fontSize: 12,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
       ),
     );
   }
@@ -269,10 +353,12 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
     // Build subtitle with scan type badge and mode
     final modeLabel = _scanModeLabel(scan.scanMode);
 
+    final accountEmail = _accountEmails[scan.accountId] ?? scan.accountId;
+
     return Card(
       elevation: 1,
       child: InkWell(
-        onTap: (isCompleted && scan.id != null && widget.platformId != null)
+        onTap: (isCompleted && scan.id != null)
             ? () => _navigateToResults(scan)
             : null,
         child: Padding(
@@ -280,6 +366,18 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Account row (when showing all accounts)
+              if (_distinctAccounts.length > 1) ...[
+                Text(
+                  accountEmail,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+              ],
               // Top row: date, type badge, status icon
               Row(
                 children: [
@@ -405,17 +503,43 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   }
 
   void _navigateToResults(ScanResult scan) {
+    // Extract platform and email from accountId format: "{platform}-{email}"
+    final dashIndex = scan.accountId.indexOf('-');
+    final platformId = dashIndex > 0
+        ? scan.accountId.substring(0, dashIndex)
+        : '';
+    final email = _accountEmails[scan.accountId] ?? scan.accountId;
+
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ResultsDisplayScreen(
-          platformId: widget.platformId ?? '',
-          platformDisplayName: widget.platformDisplayName ?? '',
+          platformId: platformId,
+          platformDisplayName: _platformDisplayName(platformId),
           accountId: scan.accountId,
-          accountEmail: widget.accountEmail ?? scan.accountId,
+          accountEmail: email,
           historicalScanId: scan.id,
         ),
       ),
     );
+  }
+
+  String _platformDisplayName(String platformId) {
+    switch (platformId) {
+      case 'aol':
+        return 'AOL';
+      case 'gmail':
+        return 'Gmail';
+      case 'gmail_oauth':
+        return 'Gmail (OAuth)';
+      case 'yahoo':
+        return 'Yahoo';
+      case 'outlook':
+        return 'Outlook.com';
+      case 'protonmail':
+        return 'ProtonMail';
+      default:
+        return platformId;
+    }
   }
 
   /// Convert full timezone name to abbreviation.

--- a/mobile-app/lib/ui/screens/scan_history_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:logger/logger.dart';
 
+import '../../adapters/storage/secure_credentials_store.dart';
 import '../../core/storage/database_helper.dart';
 import '../../core/storage/scan_result_store.dart';
 import '../../core/storage/settings_store.dart';
@@ -68,15 +69,15 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
       // Auto-purge old entries
       await _scanResultStore.purgeOldScanResults(_retentionDays);
 
+      // Load configured accounts from credentials store
+      final credStore = SecureCredentialsStore();
+      final configuredAccounts = await credStore.getSavedAccounts();
+
       // Always load all scans across all accounts
       final scans = await _scanResultStore.getAllScanHistory(limit: 500);
 
-      // Extract distinct accounts from scan data
-      final accountIds = <String>{};
-      for (final scan in scans) {
-        accountIds.add(scan.accountId);
-      }
-      final sortedAccounts = accountIds.toList()..sort();
+      // Use configured accounts as the canonical list (not scan data)
+      final sortedAccounts = List<String>.from(configuredAccounts)..sort();
 
       // Build email display map from accountId
       // accountId format is "{platform}-{email}"
@@ -148,7 +149,7 @@ class _ScanHistoryScreenState extends State<ScanHistoryScreen> {
   Widget _buildBody() {
     return Column(
       children: [
-        // Account filter chips (only show if multiple accounts)
+        // Account filter chips (show when multiple configured accounts)
         if (_distinctAccounts.length > 1) _buildAccountFilter(),
         // Type filter chips
         _buildTypeFilter(),

--- a/mobile-app/lib/ui/screens/scan_progress_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_progress_screen.dart
@@ -144,7 +144,7 @@ class _ScanProgressScreenState extends State<ScanProgressScreen> {
       },
       child: Scaffold(
         appBar: AppBarWithExit(
-          title: Text('Manual Scan - ${widget.platformDisplayName}'),
+          title: Text('Manual Scan - ${widget.accountEmail}'),
           // Add explicit back button that returns to account selection
           leading: IconButton(
             icon: const Icon(Icons.arrow_back),

--- a/mobile-app/lib/ui/screens/scan_progress_screen.dart
+++ b/mobile-app/lib/ui/screens/scan_progress_screen.dart
@@ -209,7 +209,8 @@ class _ScanProgressScreenState extends State<ScanProgressScreen> {
         ),
         body: Padding(
           padding: const EdgeInsets.all(16.0),
-          child: Column(
+          child: SelectionArea(
+            child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               _buildHeader(scanProvider),
@@ -220,6 +221,7 @@ class _ScanProgressScreenState extends State<ScanProgressScreen> {
               const SizedBox(height: 16),
               Expanded(child: _buildRecentActivity(scanProvider)),
             ],
+          ),
           ),
         ),
       ),

--- a/mobile-app/lib/ui/screens/settings_screen.dart
+++ b/mobile-app/lib/ui/screens/settings_screen.dart
@@ -2,12 +2,14 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import '../../core/services/app_environment.dart';
+import '../../core/services/default_rule_set_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:logger/logger.dart';
 import '../../core/services/background_scan_manager.dart' show ScanFrequency;
 import '../../core/services/background_scan_windows_worker.dart';
 import '../../core/services/windows_task_scheduler_service.dart';
+import '../../core/storage/database_helper.dart';
 import '../../core/storage/settings_store.dart';
 import '../../core/providers/email_scan_provider.dart';
 import '../../adapters/storage/secure_credentials_store.dart';
@@ -247,6 +249,18 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
           style: OutlinedButton.styleFrom(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             alignment: Alignment.centerLeft,
+          ),
+        ),
+        const SizedBox(height: 8),
+
+        OutlinedButton.icon(
+          icon: const Icon(Icons.restore),
+          label: const Text('Reset Rules to Defaults'),
+          onPressed: _resetRulesToDefaults,
+          style: OutlinedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            alignment: Alignment.centerLeft,
+            foregroundColor: Colors.orange.shade700,
           ),
         ),
 
@@ -1066,6 +1080,56 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
         ],
       ),
     );
+  }
+
+  /// Reset rules and safe senders to bundled defaults
+  Future<void> _resetRulesToDefaults() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reset to Defaults'),
+        content: const Text(
+          'This will replace all current rules and safe senders '
+          'with the bundled defaults. This cannot be undone.\n\n'
+          'Continue?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.orange.shade700),
+            child: const Text('Reset'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    try {
+      final dbHelper = DatabaseHelper();
+      final service = DefaultRuleSetService(dbHelper);
+      final result = await service.resetToDefaults();
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Reset complete: ${result.rules} rules, ${result.safeSenders} safe senders restored',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Reset failed: $e')),
+        );
+      }
+    }
   }
 
   /// Navigate to Scan History with account context

--- a/mobile-app/lib/ui/screens/settings_screen.dart
+++ b/mobile-app/lib/ui/screens/settings_screen.dart
@@ -181,7 +181,7 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
 
   /// F36: General tab for app-wide settings
   Widget _buildGeneralTab() {
-    return ListView(
+    return SelectionArea(child: ListView(
       padding: const EdgeInsets.all(16),
       children: [
         // Rules Management section (moved from Account tab)
@@ -319,12 +319,12 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
           ),
         ),
       ],
-    );
+    ));
   }
 
   Widget _buildAccountTab() {
     // [UPDATED] ISSUE #123: accountId now required, no null check needed
-    return FutureBuilder<Credentials?>(
+    return SelectionArea(child: FutureBuilder<Credentials?>(
       future: _credStore.getCredentials(widget.accountId),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
@@ -428,11 +428,11 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
           ],
         );
       },
-    );
+    ));
   }
 
   Widget _buildManualScanTab() {
-    return ListView(
+    return SelectionArea(child: ListView(
       padding: const EdgeInsets.all(16),
       children: [
         Card(
@@ -506,7 +506,7 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
         _buildSectionHeader('Export Settings'),
         _buildCsvExportDirectorySelector(),
       ],
-    );
+    ));
   }
 
   Widget _buildCsvExportDirectorySelector() {
@@ -631,7 +631,7 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
   }
 
   Widget _buildBackgroundScanTab() {
-    return ListView(
+    return SelectionArea(child: ListView(
       padding: const EdgeInsets.all(16),
       children: [
         SwitchListTile(
@@ -709,7 +709,7 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
           },
         ),
       ],
-    );
+    ));
   }
 
   /// [NEW] ISSUE #159: Test Background Scan button

--- a/mobile-app/lib/ui/screens/settings_screen.dart
+++ b/mobile-app/lib/ui/screens/settings_screen.dart
@@ -12,7 +12,6 @@ import '../../core/storage/settings_store.dart';
 import '../../core/providers/email_scan_provider.dart';
 import '../../adapters/storage/secure_credentials_store.dart';
 import '../../adapters/email_providers/email_provider.dart' show Credentials;
-import '../../adapters/email_providers/platform_registry.dart';
 import '../widgets/app_bar_with_exit.dart';
 import 'folder_selection_screen.dart';
 import 'scan_history_screen.dart';
@@ -1074,20 +1073,12 @@ class _SettingsScreenState extends State<SettingsScreen> with SingleTickerProvid
   /// Looks up platformId from credentials store so ScanHistoryScreen
   /// can display email details when tapping scan entries.
   Future<void> _navigateToScanHistory() async {
-    final platformId = await _credStore.getPlatformId(widget.accountId);
-    final platformDisplayName = platformId != null
-        ? (PlatformRegistry.getPlatform(platformId)?.displayName ?? platformId)
-        : null;
-
     if (!mounted) return;
 
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => ScanHistoryScreen(
-          accountId: widget.accountId,
-          accountEmail: widget.accountId,
-          platformId: platformId,
-          platformDisplayName: platformDisplayName,
+          preSelectedAccountId: widget.accountId,
         ),
       ),
     );

--- a/mobile-app/lib/ui/screens/yaml_import_export_screen.dart
+++ b/mobile-app/lib/ui/screens/yaml_import_export_screen.dart
@@ -74,7 +74,8 @@ class _YamlImportExportScreenState extends State<YamlImportExportScreen> {
       appBar: AppBarWithExit(
         title: const Text('Import / Export YAML'),
       ),
-      body: ListView(
+      body: SelectionArea(
+        child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
           // Info card
@@ -198,6 +199,7 @@ class _YamlImportExportScreenState extends State<YamlImportExportScreen> {
             const Center(child: CircularProgressIndicator()),
           ],
         ],
+      ),
       ),
     );
   }

--- a/mobile-app/test/integration/yaml_import_export_roundtrip_test.dart
+++ b/mobile-app/test/integration/yaml_import_export_roundtrip_test.dart
@@ -17,13 +17,14 @@ import 'package:my_email_spam_filter/core/services/yaml_service.dart';
 void main() {
   final yamlService = YamlService();
 
-  /// Find the repo root rules files (two directories up from mobile-app/test/)
-  String getRepoRoot() {
-    // Test runs from mobile-app/ directory
-    // Repo root contains rules.yaml and rules_safe_senders.yaml
+  /// Find the directory containing the YAML rule files.
+  ///
+  /// Rules moved from repo root to mobile-app/assets/rules/ in Sprint 20.
+  /// Tests run from mobile-app/ directory.
+  String getRulesDir() {
     final candidates = [
-      '${Directory.current.path}/../rules.yaml', // from mobile-app/
-      '${Directory.current.path}/rules.yaml',     // from repo root
+      '${Directory.current.path}/assets/rules/rules.yaml',    // from mobile-app/
+      '${Directory.current.path}/../mobile-app/assets/rules/rules.yaml', // from repo root
     ];
 
     for (final candidate in candidates) {
@@ -35,21 +36,26 @@ void main() {
     // Fallback: search up from current directory
     var dir = Directory.current;
     while (dir.path.length > 3) {
-      if (File('${dir.path}/rules.yaml').existsSync()) {
-        return dir.path;
+      final candidate = '${dir.path}/mobile-app/assets/rules/rules.yaml';
+      if (File(candidate).existsSync()) {
+        return File(candidate).parent.path;
+      }
+      final candidate2 = '${dir.path}/assets/rules/rules.yaml';
+      if (File(candidate2).existsSync()) {
+        return File(candidate2).parent.path;
       }
       dir = dir.parent;
     }
 
-    throw StateError('Could not find repo root with rules.yaml');
+    throw StateError('Could not find rules directory with rules.yaml');
   }
 
   group('YAML Rules Round-Trip', () {
-    late String repoRoot;
+    late String rulesDir;
     late Directory tempDir;
 
     setUpAll(() {
-      repoRoot = getRepoRoot();
+      rulesDir = getRulesDir();
     });
 
     setUp(() {
@@ -63,7 +69,7 @@ void main() {
     });
 
     test('export then import rules produces identical rule set', () async {
-      final rulesPath = '$repoRoot/rules.yaml';
+      final rulesPath = '$rulesDir/rules.yaml';
       expect(File(rulesPath).existsSync(), isTrue,
           reason: 'rules.yaml must exist at repo root');
 
@@ -132,7 +138,7 @@ void main() {
     });
 
     test('export then import safe senders produces identical list', () async {
-      final safeSendersPath = '$repoRoot/rules_safe_senders.yaml';
+      final safeSendersPath = '$rulesDir/rules_safe_senders.yaml';
       expect(File(safeSendersPath).existsSync(), isTrue,
           reason: 'rules_safe_senders.yaml must exist at repo root');
 
@@ -177,7 +183,7 @@ void main() {
     });
 
     test('double export produces identical YAML content', () async {
-      final safeSendersPath = '$repoRoot/rules_safe_senders.yaml';
+      final safeSendersPath = '$rulesDir/rules_safe_senders.yaml';
       final original = await yamlService.loadSafeSenders(safeSendersPath);
 
       // Export twice to different files
@@ -197,7 +203,7 @@ void main() {
     });
 
     test('double export produces identical rules YAML content', () async {
-      final rulesPath = '$repoRoot/rules.yaml';
+      final rulesPath = '$rulesDir/rules.yaml';
       final original = await yamlService.loadRules(rulesPath);
 
       // Export twice
@@ -231,7 +237,7 @@ void main() {
     });
 
     test('safe senders count matches expected range', () async {
-      final safeSendersPath = '$repoRoot/rules_safe_senders.yaml';
+      final safeSendersPath = '$rulesDir/rules_safe_senders.yaml';
       final safeSenders = await yamlService.loadSafeSenders(safeSendersPath);
 
       // The repo has hundreds of safe sender patterns
@@ -240,7 +246,7 @@ void main() {
     });
 
     test('rules count matches expected range', () async {
-      final rulesPath = '$repoRoot/rules.yaml';
+      final rulesPath = '$rulesDir/rules.yaml';
       final rules = await yamlService.loadRules(rulesPath);
 
       // The repo has multiple rules
@@ -249,7 +255,7 @@ void main() {
     });
 
     test('every reimported rule has valid regex patterns', () async {
-      final rulesPath = '$repoRoot/rules.yaml';
+      final rulesPath = '$rulesDir/rules.yaml';
       final original = await yamlService.loadRules(rulesPath);
 
       // Export and reimport
@@ -297,7 +303,7 @@ void main() {
     });
 
     test('every reimported safe sender pattern is a valid regex', () async {
-      final safeSendersPath = '$repoRoot/rules_safe_senders.yaml';
+      final safeSendersPath = '$rulesDir/rules_safe_senders.yaml';
       final original = await yamlService.loadSafeSenders(safeSendersPath);
 
       // Export and reimport

--- a/mobile-app/test/unit/services/default_rule_set_service_test.dart
+++ b/mobile-app/test/unit/services/default_rule_set_service_test.dart
@@ -1,0 +1,295 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:my_email_spam_filter/core/services/default_rule_set_service.dart';
+import '../../helpers/database_test_helper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late DatabaseTestHelper testHelper;
+  late DefaultRuleSetService service;
+
+  setUpAll(() {
+    DatabaseTestHelper.initializeFfi();
+  });
+
+  setUp(() async {
+    testHelper = DatabaseTestHelper();
+    await testHelper.setUp();
+    service = DefaultRuleSetService(testHelper.dbHelper);
+  });
+
+  tearDown(() async {
+    await testHelper.tearDown();
+  });
+
+  group('DefaultRuleSetService', () {
+    group('seedIfEmpty', () {
+      test('skips seeding when rules already exist', () async {
+        // Pre-populate with one rule
+        final db = await testHelper.dbHelper.database;
+        await db.insert('rules', {
+          'name': 'Existing rule',
+          'enabled': 1,
+          'is_local': 0,
+          'execution_order': 1,
+          'condition_type': 'OR',
+          'action_delete': 0,
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+
+        final result = await service.seedIfEmpty();
+
+        expect(result.rules, 0);
+        expect(result.safeSenders, 0);
+
+        // Verify only the original rule exists (no seeding occurred)
+        final rules = await db.query('rules');
+        expect(rules, hasLength(1));
+        expect(rules[0]['name'], 'Existing rule');
+      });
+
+      test('skips seeding when safe senders already exist', () async {
+        // Pre-populate with one safe sender (include all NOT NULL fields)
+        final db = await testHelper.dbHelper.database;
+        await db.insert('safe_senders', {
+          'pattern': '^existing@test\\.com\$',
+          'pattern_type': 'regex',
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+
+        final result = await service.seedIfEmpty();
+
+        expect(result.rules, 0);
+        expect(result.safeSenders, 0);
+
+        // Verify only the original safe sender exists
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, hasLength(1));
+        expect(safeSenders[0]['pattern'], '^existing@test\\.com\$');
+      });
+
+      test('skips seeding when both rules and safe senders exist', () async {
+        final db = await testHelper.dbHelper.database;
+        await db.insert('rules', {
+          'name': 'Existing rule',
+          'enabled': 1,
+          'is_local': 0,
+          'execution_order': 1,
+          'condition_type': 'OR',
+          'action_delete': 0,
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+        await db.insert('safe_senders', {
+          'pattern': '^existing@test\\.com\$',
+          'pattern_type': 'regex',
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+
+        final result = await service.seedIfEmpty();
+
+        expect(result.rules, 0);
+        expect(result.safeSenders, 0);
+      });
+
+      test('seeds rules and safe senders on empty database', () async {
+        final result = await service.seedIfEmpty();
+
+        expect(result.rules, 5);
+        expect(result.safeSenders, greaterThan(0));
+
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules');
+        expect(rules, hasLength(5));
+
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, isNotEmpty);
+      });
+    });
+
+    group('resetToDefaults', () {
+      test('seeds rules and safe senders from bundled YAML assets', () async {
+        final result = await service.resetToDefaults();
+
+        expect(result.rules, 5);
+        expect(result.safeSenders, greaterThan(0));
+
+        // Verify rules were inserted into the database
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules', orderBy: 'execution_order');
+        expect(rules, hasLength(5));
+
+        // Verify safe senders were inserted
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, isNotEmpty);
+
+        // Verify first rule structure
+        final firstRule = rules[0];
+        expect(firstRule['name'], isNotNull);
+        expect(firstRule['enabled'], isIn([0, 1]));
+        expect(firstRule['is_local'], isIn([0, 1]));
+        expect(firstRule['execution_order'], isNotNull);
+        expect(firstRule['condition_type'], isNotNull);
+        expect(firstRule['created_by'], 'default');
+        expect(firstRule['date_added'], isNotNull);
+      });
+
+      test('clears existing user rules before seeding defaults', () async {
+        // Pre-populate with user data
+        final db = await testHelper.dbHelper.database;
+        await db.insert('rules', {
+          'name': 'User custom rule',
+          'enabled': 1,
+          'is_local': 1,
+          'execution_order': 99,
+          'condition_type': 'AND',
+          'action_delete': 1,
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+        await db.insert('safe_senders', {
+          'pattern': '^user@custom\\.com\$',
+          'pattern_type': 'regex',
+          'date_added': DateTime.now().millisecondsSinceEpoch,
+          'created_by': 'user',
+        });
+
+        // Verify pre-populated data exists
+        var rules = await db.query('rules');
+        expect(rules, hasLength(1));
+        expect(rules[0]['name'], 'User custom rule');
+
+        // Reset to defaults
+        final result = await service.resetToDefaults();
+
+        expect(result.rules, 5);
+
+        // Verify user rules were replaced by defaults
+        rules = await db.query('rules');
+        expect(rules, hasLength(5));
+        // None of the rules should be the user's custom rule
+        expect(
+          rules.every((r) => r['name'] != 'User custom rule'),
+          isTrue,
+        );
+        // All rules should be created_by 'default'
+        expect(
+          rules.every((r) => r['created_by'] == 'default'),
+          isTrue,
+        );
+
+        // User safe sender was replaced by defaults
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, isNotEmpty);
+        // None should be the user's custom sender
+        expect(
+          safeSenders.every((s) => s['pattern'] != '^user@custom\\.com\$'),
+          isTrue,
+        );
+      });
+
+      test('verifies correct rule field mapping from YAML to database', () async {
+        await service.resetToDefaults();
+
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules', orderBy: 'execution_order');
+
+        // Verify first rule has expected structure from the bundled YAML
+        // The first rule is SpamAutoDeleteHeader with header conditions
+        final rule1 = rules[0];
+        expect(rule1['name'], 'SpamAutoDeleteHeader');
+        expect(rule1['enabled'], 1); // True -> 1
+        expect(rule1['is_local'], 1); // True -> 1
+        expect(rule1['execution_order'], 1);
+        expect(rule1['condition_type'], 'OR');
+
+        // Should have header conditions (JSON array)
+        expect(rule1['condition_header'], isNotNull);
+        final headerPatterns = jsonDecode(rule1['condition_header'] as String);
+        expect(headerPatterns, isList);
+        expect(headerPatterns, isNotEmpty);
+
+        // Should have delete action set
+        expect(rule1['action_delete'], 1);
+
+        // Optional exception fields should be null for this rule
+        expect(rule1['exception_from'], isNull);
+
+        // Metadata may be present if the bundled YAML includes it
+        if (rule1['metadata'] != null) {
+          final metadata = jsonDecode(rule1['metadata'] as String);
+          expect(metadata, isA<Map>());
+        }
+      });
+
+      test('can be called multiple times without duplicate rules', () async {
+        // First reset
+        var result = await service.resetToDefaults();
+        expect(result.rules, 5);
+
+        // Second reset should clear and re-seed (no duplicates)
+        result = await service.resetToDefaults();
+        expect(result.rules, 5);
+
+        // Verify no duplicates
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules');
+        expect(rules, hasLength(5));
+      });
+
+      test('works on already empty database', () async {
+        final result = await service.resetToDefaults();
+
+        expect(result.rules, 5);
+        expect(result.safeSenders, greaterThan(0));
+
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules');
+        expect(rules, hasLength(5));
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, isNotEmpty);
+      });
+
+      test('safe senders have correct pattern_type classification', () async {
+        await service.resetToDefaults();
+
+        final db = await testHelper.dbHelper.database;
+        final safeSenders = await db.query('safe_senders');
+        expect(safeSenders, isNotEmpty);
+
+        // All safe senders should have a non-null pattern_type
+        for (final ss in safeSenders) {
+          expect(ss['pattern_type'], isNotNull);
+          expect(
+            ss['pattern_type'],
+            isIn(['exact_email', 'exact_domain', 'entire_domain']),
+          );
+        }
+      });
+    });
+
+    group('seedIfEmpty and resetToDefaults interaction', () {
+      test('seedIfEmpty skips after resetToDefaults has populated data', () async {
+        // Reset seeds the database with rules
+        final resetResult = await service.resetToDefaults();
+        expect(resetResult.rules, 5);
+
+        // seedIfEmpty should skip since rules exist
+        final seedResult = await service.seedIfEmpty();
+        expect(seedResult.rules, 0);
+        expect(seedResult.safeSenders, 0);
+
+        // Verify only 5 rules exist (no duplicates from attempted seed)
+        final db = await testHelper.dbHelper.database;
+        final rules = await db.query('rules');
+        expect(rules, hasLength(5));
+      });
+    });
+  });
+}

--- a/mobile-app/test/unit/services/email_scanner_test.dart
+++ b/mobile-app/test/unit/services/email_scanner_test.dart
@@ -1,0 +1,345 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_email_spam_filter/core/services/email_scanner.dart';
+import 'package:my_email_spam_filter/core/providers/email_scan_provider.dart';
+import 'package:my_email_spam_filter/core/providers/rule_set_provider.dart';
+
+void main() {
+  late EmailScanProvider scanProvider;
+  late RuleSetProvider ruleSetProvider;
+
+  setUp(() {
+    scanProvider = EmailScanProvider();
+    ruleSetProvider = RuleSetProvider();
+  });
+
+  group('EmailScanner constructor', () {
+    test('stores platformId correctly', () {
+      final scanner = EmailScanner(
+        platformId: 'aol',
+        accountId: 'aol-user@aol.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(scanner.platformId, 'aol');
+    });
+
+    test('stores accountId correctly', () {
+      final scanner = EmailScanner(
+        platformId: 'gmail',
+        accountId: 'gmail-user@gmail.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(scanner.accountId, 'gmail-user@gmail.com');
+    });
+
+    test('stores ruleSetProvider correctly', () {
+      final scanner = EmailScanner(
+        platformId: 'aol',
+        accountId: 'test@aol.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(scanner.ruleSetProvider, same(ruleSetProvider));
+    });
+
+    test('stores scanProvider correctly', () {
+      final scanner = EmailScanner(
+        platformId: 'aol',
+        accountId: 'test@aol.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(scanner.scanProvider, same(scanProvider));
+    });
+  });
+
+  group('scanInbox with unsupported platform', () {
+    test('throws exception for unknown platformId', () async {
+      final scanner = EmailScanner(
+        platformId: 'unsupported-provider',
+        accountId: 'user@unsupported.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanInbox(daysBack: 7),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Platform unsupported-provider not supported'),
+        )),
+      );
+    });
+
+    test('sets scanProvider to error state for unknown platformId', () async {
+      final scanner = EmailScanner(
+        platformId: 'unknown-platform',
+        accountId: 'user@unknown.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      try {
+        await scanner.scanInbox(daysBack: 7);
+      } catch (_) {
+        // Expected
+      }
+
+      expect(scanProvider.status, ScanStatus.error);
+      expect(scanProvider.statusMessage, contains('Scan failed'));
+      expect(scanProvider.statusMessage, contains('unknown-platform not supported'));
+    });
+
+    test('accepts default parameters', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanInbox(),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('accepts custom daysBack parameter', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanInbox(daysBack: 30),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('accepts custom folderNames parameter', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanInbox(folderNames: ['INBOX', 'Spam']),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('accepts custom scanType parameter', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanInbox(scanType: 'background'),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('scanFolders', () {
+    test('throws for unsupported platform (delegates to scanInbox)', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent-platform',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanFolders(folderNames: ['INBOX', 'Junk']),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('nonexistent-platform not supported'),
+        )),
+      );
+    });
+
+    test('sets error state on scanProvider when platform not found', () async {
+      final scanner = EmailScanner(
+        platformId: 'bad-platform',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      try {
+        await scanner.scanFolders(folderNames: ['INBOX'], daysBack: 14);
+      } catch (_) {
+        // Expected
+      }
+
+      expect(scanProvider.status, ScanStatus.error);
+    });
+
+    test('accepts default daysBack of 7', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanFolders(folderNames: ['Spam']),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('scanAllFolders', () {
+    test('throws for unsupported platform', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent-platform',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanAllFolders(daysBack: 7),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('nonexistent-platform not supported'),
+        )),
+      );
+    });
+
+    test('throws when credentials not found for valid platform', () async {
+      // Uses 'demo' which is a valid platform, but scanAllFolders
+      // always tries to load credentials (unlike scanInbox which skips for demo).
+      // However, SecureCredentialsStore will fail in test environment.
+      // The 'aol' platform is registered but credential lookup will fail.
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(
+        () => scanner.scanAllFolders(),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('EmailScanner multiple instances', () {
+    test('different scanners have independent configuration', () {
+      final scanner1 = EmailScanner(
+        platformId: 'aol',
+        accountId: 'user1@aol.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      final scanProvider2 = EmailScanProvider();
+      final scanner2 = EmailScanner(
+        platformId: 'gmail',
+        accountId: 'user2@gmail.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider2,
+      );
+
+      expect(scanner1.platformId, 'aol');
+      expect(scanner2.platformId, 'gmail');
+      expect(scanner1.accountId, 'user1@aol.com');
+      expect(scanner2.accountId, 'user2@gmail.com');
+      expect(scanner1.scanProvider, isNot(same(scanner2.scanProvider)));
+    });
+
+    test('scanners can share ruleSetProvider', () {
+      final scanner1 = EmailScanner(
+        platformId: 'aol',
+        accountId: 'user1@aol.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      final scanner2 = EmailScanner(
+        platformId: 'gmail',
+        accountId: 'user2@gmail.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: EmailScanProvider(),
+      );
+
+      expect(scanner1.ruleSetProvider, same(scanner2.ruleSetProvider));
+    });
+  });
+
+  group('error handling behavior', () {
+    test('scanProvider remains idle before scan attempt', () {
+      EmailScanner(
+        platformId: 'test',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      expect(scanProvider.status, ScanStatus.idle);
+      expect(scanProvider.processedCount, 0);
+      expect(scanProvider.totalEmails, 0);
+    });
+
+    test('consecutive scan failures update scanProvider error state each time', () async {
+      final scanner = EmailScanner(
+        platformId: 'nonexistent',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      try {
+        await scanner.scanInbox();
+      } catch (_) {}
+
+      expect(scanProvider.status, ScanStatus.error);
+
+      // Second scan attempt also sets error
+      try {
+        await scanner.scanInbox();
+      } catch (_) {}
+
+      expect(scanProvider.status, ScanStatus.error);
+      expect(scanProvider.statusMessage, contains('Scan failed'));
+    });
+
+    test('scanInbox rethrows the exception after setting error state', () async {
+      final scanner = EmailScanner(
+        platformId: 'unknown',
+        accountId: 'test@test.com',
+        ruleSetProvider: ruleSetProvider,
+        scanProvider: scanProvider,
+      );
+
+      Exception? caughtException;
+      try {
+        await scanner.scanInbox();
+      } on Exception catch (e) {
+        caughtException = e;
+      }
+
+      expect(caughtException, isNotNull);
+      expect(caughtException.toString(), contains('unknown not supported'));
+      expect(scanProvider.status, ScanStatus.error);
+    });
+  });
+}

--- a/mobile-app/test/unit/services/yaml_service_test.dart
+++ b/mobile-app/test/unit/services/yaml_service_test.dart
@@ -1,0 +1,323 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_email_spam_filter/core/services/yaml_service.dart';
+
+void main() {
+  late YamlService yamlService;
+
+  setUp(() {
+    yamlService = YamlService();
+  });
+
+  group('parseRulesFromString', () {
+    test('parses valid YAML with a single rule', () {
+      const yaml = '''
+version: '2.0'
+settings:
+  mode: regex
+rules:
+  - name: Block spam domain
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 1
+    conditions:
+      type: OR
+      header:
+        - '@spam\\.com\$'
+    actions:
+      delete: true
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+
+      expect(ruleSet.version, '2.0');
+      expect(ruleSet.settings['mode'], 'regex');
+      expect(ruleSet.rules, hasLength(1));
+
+      final rule = ruleSet.rules.first;
+      expect(rule.name, 'Block spam domain');
+      expect(rule.enabled, isTrue);
+      expect(rule.isLocal, isFalse);
+      expect(rule.executionOrder, 1);
+      expect(rule.conditions.type, 'OR');
+      expect(rule.conditions.header, [r'@spam\.com$']);
+      expect(rule.actions.delete, isTrue);
+      expect(rule.exceptions, isNull);
+    });
+
+    test('parses multiple rules with different condition types', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules:
+  - name: Header rule
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 1
+    conditions:
+      type: OR
+      header:
+        - '@example\\.com\$'
+    actions:
+      delete: false
+      move_to_folder: Junk
+  - name: Subject rule
+    enabled: 'true'
+    isLocal: 'true'
+    executionOrder: 2
+    conditions:
+      type: AND
+      subject:
+        - 'free money'
+        - 'act now'
+    actions:
+      delete: true
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+
+      expect(ruleSet.rules, hasLength(2));
+
+      final headerRule = ruleSet.rules[0];
+      expect(headerRule.name, 'Header rule');
+      expect(headerRule.conditions.header, hasLength(1));
+      expect(headerRule.actions.delete, isFalse);
+      expect(headerRule.actions.moveToFolder, 'Junk');
+
+      final subjectRule = ruleSet.rules[1];
+      expect(subjectRule.name, 'Subject rule');
+      expect(subjectRule.isLocal, isTrue);
+      expect(subjectRule.executionOrder, 2);
+      expect(subjectRule.conditions.type, 'AND');
+      expect(subjectRule.conditions.subject, hasLength(2));
+      expect(subjectRule.actions.delete, isTrue);
+    });
+
+    test('parses rule with exceptions', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules:
+  - name: Rule with exceptions
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 1
+    conditions:
+      type: OR
+      from:
+        - '@marketing\\.com\$'
+    actions:
+      delete: true
+    exceptions:
+      from:
+        - '^support@marketing\\.com\$'
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+      final rule = ruleSet.rules.first;
+
+      expect(rule.exceptions, isNotNull);
+      expect(rule.exceptions!.from, hasLength(1));
+      expect(rule.exceptions!.from.first, r'^support@marketing\.com$');
+    });
+
+    test('parses rule with classification fields', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules:
+  - name: Classified rule
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 1
+    patternCategory: header_from
+    patternSubType: entire_domain
+    sourceDomain: spammer.com
+    conditions:
+      type: OR
+      header:
+        - '@(?:[a-z0-9-]+\\.)*spammer\\.com\$'
+    actions:
+      delete: true
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+      final rule = ruleSet.rules.first;
+
+      expect(rule.patternCategory, 'header_from');
+      expect(rule.patternSubType, 'entire_domain');
+      expect(rule.sourceDomain, 'spammer.com');
+    });
+
+    test('handles empty rules list', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules: []
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+
+      expect(ruleSet.version, '1.0');
+      expect(ruleSet.rules, isEmpty);
+    });
+
+    test('handles missing optional fields with defaults', () {
+      const yaml = '''
+rules:
+  - name: Minimal rule
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 0
+    conditions:
+      type: OR
+    actions:
+      delete: false
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+
+      // Version defaults to '1.0' when missing
+      expect(ruleSet.version, '1.0');
+      // Settings defaults to empty map when missing
+      expect(ruleSet.settings, isEmpty);
+
+      final rule = ruleSet.rules.first;
+      expect(rule.conditions.from, isEmpty);
+      expect(rule.conditions.header, isEmpty);
+      expect(rule.conditions.subject, isEmpty);
+      expect(rule.conditions.body, isEmpty);
+      expect(rule.exceptions, isNull);
+      expect(rule.patternCategory, isNull);
+    });
+
+    test('parses rule with body conditions', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules:
+  - name: Body pattern rule
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 5
+    conditions:
+      type: OR
+      body:
+        - 'click here to unsubscribe'
+        - 'you have been selected'
+    actions:
+      delete: true
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+      final rule = ruleSet.rules.first;
+
+      expect(rule.conditions.body, hasLength(2));
+      expect(rule.conditions.body[0], 'click here to unsubscribe');
+      expect(rule.conditions.body[1], 'you have been selected');
+    });
+
+    test('parses rule with assign_to_category action', () {
+      const yaml = '''
+version: '1.0'
+settings: {}
+rules:
+  - name: Categorize rule
+    enabled: 'true'
+    isLocal: 'false'
+    executionOrder: 1
+    conditions:
+      type: OR
+      from:
+        - '@newsletter\\.com\$'
+    actions:
+      delete: false
+      assign_to_category: Promotions
+''';
+
+      final ruleSet = yamlService.parseRulesFromString(yaml);
+      final rule = ruleSet.rules.first;
+
+      expect(rule.actions.assignToCategory, 'Promotions');
+      expect(rule.actions.delete, isFalse);
+    });
+  });
+
+  group('parseSafeSendersFromString', () {
+    test('parses valid safe senders YAML', () {
+      const yaml = '''
+safe_senders:
+  - '^[^@\\s]+@(?:[a-z0-9-]+\\.)*trusted\\.com\$'
+  - '^support@example\\.com\$'
+  - '^[^@\\s]+@safe\\.org\$'
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders, hasLength(3));
+      expect(
+        safeSenders.safeSenders[0],
+        r'^[^@\s]+@(?:[a-z0-9-]+\.)*trusted\.com$',
+      );
+      expect(safeSenders.safeSenders[1], r'^support@example\.com$');
+      expect(safeSenders.safeSenders[2], r'^[^@\s]+@safe\.org$');
+    });
+
+    test('handles empty safe senders list', () {
+      const yaml = '''
+safe_senders: []
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders, isEmpty);
+    });
+
+    test('normalizes entries to lowercase', () {
+      const yaml = '''
+safe_senders:
+  - 'Admin@Example.COM'
+  - 'USER@DOMAIN.ORG'
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders[0], 'admin@example.com');
+      expect(safeSenders.safeSenders[1], 'user@domain.org');
+    });
+
+    test('handles missing safe_senders key gracefully', () {
+      const yaml = '''
+other_key: value
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders, isEmpty);
+    });
+
+    test('trims whitespace from entries', () {
+      const yaml = '''
+safe_senders:
+  - '  spaced@example.com  '
+  - 'normal@example.com'
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders[0], 'spaced@example.com');
+      expect(safeSenders.safeSenders[1], 'normal@example.com');
+    });
+
+    test('parses single safe sender entry', () {
+      const yaml = '''
+safe_senders:
+  - '^only@one\\.com\$'
+''';
+
+      final safeSenders = yamlService.parseSafeSendersFromString(yaml);
+
+      expect(safeSenders.safeSenders, hasLength(1));
+      expect(safeSenders.safeSenders.first, r'^only@one\.com$');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **feat**: Make all page text selectable and copyable across 21 screens (F50, Issue #220)
- **feat**: Scan History enhancements - multi-account combined view, account/type filters, totals with tooltips, retention days in title (F48, Issue #212)
- **feat**: Default rule set creation - seed from bundled YAML on fresh install, Reset to Defaults in Settings (F46, Issue #208)
- **test**: Add 53 new tests for email_scanner, default_rule_set_service, yaml_service (F42, Issue #203)
- **fix**: YAML round-trip test path after rules moved to assets/rules/ - fixes pre-existing test failure (0 failures now)
- **fix**: Testing feedback - Results screen selectable text, account setup dialog selectable text, Scan History account filter, Manual Scan title, totals left-alignment, removed redundant account selection dialog
- **docs**: Backlog refinement - cleaned completed items from ALL_SPRINTS_MASTER_PLAN.md, added F52-F56 backlog items
- **docs**: ASRD review - correct ADR counts, eliminate duplicate details across architecture docs, accept ADR-0027/0028/0032/0033 with Product Owner decisions, platform expansion validation, formally exclude browser target
- **docs**: Add GenAI Happy Hour presentation framework

## Metrics

| Metric | Before | After |
|--------|--------|-------|
| Tests passing | 1170 | 1223 (+53) |
| Test failures | 1 | 0 |
| Analyze issues | 0 | 0 |
| Screens with selectable text | 5 | 21 |

## Test plan

- [x] `flutter test` - 1223 passing, 28 skipped, 0 failures
- [x] `flutter analyze` - 0 issues
- [x] Windows desktop build and launch
- [x] Manual testing by product owner (April 8-11)
- [x] Testing feedback fixes applied and verified
- [x] Winwright accessibility tree verified (24 elements visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)