### PR TITLE
Add Copilot code review custom instructions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,13 @@
 #
 # Syntax: pattern<space>@user1 @user2 ...
 # Later rules override earlier ones. Most-specific rule wins.
+#
+# Note on Copilot: CODEOWNERS does NOT support the Copilot bot
+# (copilot-pull-request-reviewer is a Bot account, not resolvable here).
+# To auto-request Copilot review, use a Repository Ruleset instead:
+# Settings -> Rules -> Rulesets -> New branch ruleset ->
+# enable "Automatically request Copilot code review"
 
 # Default owners for everything in the repo
 # - @kimmeyh: Project owner / Chief Architect / Chief Developer
-# - @copilot-pull-request-reviewer: GitHub Copilot automated code review
-#   (see Phase 6.4.1 for how Claude Code drafts responses to Copilot feedback)
-*       @kimmeyh @copilot-pull-request-reviewer
+*       @kimmeyh

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,15 +2,19 @@
 
 Scope: flag real issues in PR diffs. Out of scope: formatting handled by `flutter analyze` and `dart format`.
 
+## Repository Layout
+
+This repository is a monorepo. The Flutter/Dart app lives under `mobile-app/` (code in `mobile-app/lib/`, tests in `mobile-app/test/`). Sibling top-level directories (`docs/`, `scripts/`, `.github/`, `rules.yaml`) are not Flutter code. Flutter-specific rules below apply only to files under `mobile-app/`.
+
 ## Project
 
-Cross-platform Flutter/Dart email spam filter. Primary targets: Windows 11 (Microsoft Store) and Android. Provider-agnostic core (`lib/core/`), adapter pattern (`lib/adapters/`), Flutter UI (`lib/ui/`). IMAP + OAuth for AOL, Gmail, Yahoo. Rules and safe-senders use regex patterns in YAML and a SQLite DB.
+Cross-platform Flutter/Dart email spam filter. Primary targets: Windows 11 (Microsoft Store) and Android. Provider-agnostic core (`mobile-app/lib/core/`), adapter pattern (`mobile-app/lib/adapters/`), Flutter UI (`mobile-app/lib/ui/`). IMAP + OAuth for AOL, Gmail, Yahoo. Rules and safe-senders use regex patterns in YAML and a SQLite DB.
 
 ## Flag These
 
 ### Security
 - Secrets in code: `secrets.dev.json`, `google-services.json`, `client_secret_*.json`, API keys, OAuth tokens, passwords in strings or logs.
-- Unredacted email addresses or tokens in log statements. Use `Redact.email()`, `Redact.accountId()`, `Redact.token()` from `lib/util/redact.dart`.
+- Unredacted email addresses or tokens in log statements. Use `Redact.email()`, `Redact.accountId()`, `Redact.token()` from `mobile-app/lib/util/redact.dart`.
 - Direct `regex.hasMatch()` on user-provided patterns without timeout protection. Prefer `PatternCompiler.safeHasMatch()` or gate with `PatternCompiler.detectReDoS()`.
 - Raw SQL string concatenation. All DB operations must be parameterized.
 - Missing input validation at trust boundaries (user input, external APIs, YAML imports).
@@ -22,20 +26,20 @@ Cross-platform Flutter/Dart email spam filter. Primary targets: Windows 11 (Micr
 - Null-safety errors the analyzer missed.
 
 ### Conventions
-- Use `Logger` (package:logger) in `lib/`. `print()` only in `test/`.
-- No contractions in comments or docs: "do not" not "don't", "cannot" not "can't".
+- Use `Logger` (package:logger) in `mobile-app/lib/`. `print()` only in `mobile-app/test/`.
+- No contractions in comments or docs. Use "do not" and "cannot".
 - No emojis in code or logs. Use `[OK]`, `[FAIL]`, `[WARNING]`, `[PENDING]`. Customer-facing UI text is the only exception.
-- PowerShell is primary shell. Flag bash-only syntax in developer scripts.
-- No Linux tools (`jq`, `sed`, `awk`, `grep`, `find`, `cat`) in scripts.
+- PowerShell is the primary shell for developer scripts. Flag bash-only syntax.
+- No UNIX/GNU-style CLI tools (`jq`, `sed`, `awk`, `grep`) in scripts. Use PowerShell cmdlets or Flutter tooling. Note: `cat`, `find`, `ls` are also PowerShell aliases on Windows, so flag only when used with UNIX-style arguments.
 
 ### Architecture
-- Core (`lib/core/`) must not import adapters (`lib/adapters/`). Adapters may import core.
+- Core (`mobile-app/lib/core/`) must not import adapters (`mobile-app/lib/adapters/`). Adapters may import core.
 - Storage goes through `AppPaths`. Flag hardcoded paths like `AppData\Roaming\...`.
 - DB is sole source of truth for rules since Sprint 20. Flag dual-write patterns (YAML + DB) reintroduced.
 - Platform-specific code must be guarded with `Platform.isWindows` / `isAndroid`, not assumed.
 
 ### Testing
-- New code in `lib/` should have matching tests in `test/`. Flag `lib/` additions without tests.
+- New code in `mobile-app/lib/` should have matching tests in `mobile-app/test/`. Flag `mobile-app/lib/` additions without tests.
 - Prefer integration tests over mocks for DB and storage code.
 - Do not lower assertions to pass tests; fix the underlying code.
 
@@ -45,7 +49,7 @@ Cross-platform Flutter/Dart email spam filter. Primary targets: Windows 11 (Micr
 
 ## Cross-Cutting Pattern Sweep
 
-When a PR applies a pattern that should be codebase-wide (logging redaction, error handling, input validation, accessibility), check whether similar sites elsewhere in `lib/` were missed. Tag as `POTENTIAL_MISS: <file:line>`.
+When a PR applies a pattern that should be codebase-wide (logging redaction, error handling, input validation, accessibility), check whether similar sites elsewhere in `mobile-app/lib/` were missed. Tag as `POTENTIAL_MISS: <file:line>`.
 
 ## De-Emphasize
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Code Review Instructions
+
+Scope: flag real issues in PR diffs. Out of scope: formatting handled by `flutter analyze` and `dart format`.
+
+## Project
+
+Cross-platform Flutter/Dart email spam filter. Primary targets: Windows 11 (Microsoft Store) and Android. Provider-agnostic core (`lib/core/`), adapter pattern (`lib/adapters/`), Flutter UI (`lib/ui/`). IMAP + OAuth for AOL, Gmail, Yahoo. Rules and safe-senders use regex patterns in YAML and a SQLite DB.
+
+## Flag These
+
+### Security
+- Secrets in code: `secrets.dev.json`, `google-services.json`, `client_secret_*.json`, API keys, OAuth tokens, passwords in strings or logs.
+- Unredacted email addresses or tokens in log statements. Use `Redact.email()`, `Redact.accountId()`, `Redact.token()` from `lib/util/redact.dart`.
+- Direct `regex.hasMatch()` on user-provided patterns without timeout protection. Prefer `PatternCompiler.safeHasMatch()` or gate with `PatternCompiler.detectReDoS()`.
+- Raw SQL string concatenation. All DB operations must be parameterized.
+- Missing input validation at trust boundaries (user input, external APIs, YAML imports).
+
+### Correctness
+- State bugs: `ChangeNotifier` mutations without `notifyListeners()`; historical vs. live data confusion (see `ResultsDisplayScreen` where `historicalScanId` must take precedence over live provider results).
+- Async misuse: missing `await`, unhandled `Future`, `setState` after `dispose`.
+- Silent failures: empty catch blocks, `catch (e) {}` without logging, fallbacks that hide errors. Log with `Logger.w()` at minimum.
+- Null-safety errors the analyzer missed.
+
+### Conventions
+- Use `Logger` (package:logger) in `lib/`. `print()` only in `test/`.
+- No contractions in comments or docs: "do not" not "don't", "cannot" not "can't".
+- No emojis in code or logs. Use `[OK]`, `[FAIL]`, `[WARNING]`, `[PENDING]`. Customer-facing UI text is the only exception.
+- PowerShell is primary shell. Flag bash-only syntax in developer scripts.
+- No Linux tools (`jq`, `sed`, `awk`, `grep`, `find`, `cat`) in scripts.
+
+### Architecture
+- Core (`lib/core/`) must not import adapters (`lib/adapters/`). Adapters may import core.
+- Storage goes through `AppPaths`. Flag hardcoded paths like `AppData\Roaming\...`.
+- DB is sole source of truth for rules since Sprint 20. Flag dual-write patterns (YAML + DB) reintroduced.
+- Platform-specific code must be guarded with `Platform.isWindows` / `isAndroid`, not assumed.
+
+### Testing
+- New code in `lib/` should have matching tests in `test/`. Flag `lib/` additions without tests.
+- Prefer integration tests over mocks for DB and storage code.
+- Do not lower assertions to pass tests; fix the underlying code.
+
+### PR Hygiene
+- Claude Code PRs target `develop`, never `main`. Flag PRs targeting `main` from a feature branch.
+- CHANGELOG.md must be updated for user-facing changes under `## [Unreleased]`.
+
+## Cross-Cutting Pattern Sweep
+
+When a PR applies a pattern that should be codebase-wide (logging redaction, error handling, input validation, accessibility), check whether similar sites elsewhere in `lib/` were missed. Tag as `POTENTIAL_MISS: <file:line>`.
+
+## De-Emphasize
+
+- Formatting, whitespace, import ordering (handled by `dart format` + `flutter analyze`).
+- Naming bikesheds when the existing name is clear.
+- Doc style beyond "no contractions, no emojis".
+- Refactors unrelated to the PR's purpose.

--- a/docs/SPRINT_EXECUTION_WORKFLOW.md
+++ b/docs/SPRINT_EXECUTION_WORKFLOW.md
@@ -726,33 +726,35 @@ After Phase 5.2 all tests pass, context can be compacted for efficiency:
   - Reference all sprint cards: `Closes #XX, #YY, #ZZ`
 
 - [ ] **6.4 Assign Code Review**
-  - Assign GitHub Copilot for automated review (if enabled in repo settings)
-  - Add user as reviewer if manual review needed
-  - Request specific review focus if applicable
+  - **@kimmeyh** is auto-assigned via `.github/CODEOWNERS`.
+  - **Copilot** is auto-assigned via Repository Ruleset (Settings -> Rules -> Rulesets -> enable "Automatically request Copilot code review"). Note: CODEOWNERS does NOT support the Copilot bot; the Ruleset is the only supported mechanism.
+  - Fallback if Ruleset is not configured and Copilot review is desired: `gh pr edit <PR#> --add-reviewer "@copilot"` (requires gh CLI v2.88.0+).
+  - Copilot instructions come from `.github/copilot-instructions.md` on the PR base branch (develop).
 
 - [ ] **6.4.1 GitHub Copilot Review Response** (Sprint 32 improvement - if Copilot enabled)
   - **Purpose**: External review layer independent of Claude Code. Catches language-specific issues, convention violations, best-practice gaps.
-  - **Trigger**: Wait for Copilot review to complete after PR creation (typically 1-3 minutes)
+  - **Trigger**: Wait for Copilot review to complete after PR creation (typically 1-3 minutes).
+  - **Known gotcha**: The auto-assignment Ruleset fires on push to an existing PR, not reliably at PR creation. If a PR opens with a single initial commit and Copilot review does not appear within 3-5 minutes, push a follow-up commit or manually request via `gh pr edit <PR#> --add-reviewer "@copilot"`.
   - **Process**:
-    1. Fetch Copilot review comments: `gh pr view <PR#> --json reviews,reviewThreads` or review on GitHub UI
-    2. For each Copilot comment, draft a response with **three fields**:
-       - **What**: Copilot's feedback quoted or summarized
-       - **Why**: Context of the code being reviewed
-       - **Impact**: What would change if addressed (similar to mini-ADR)
+    1. Fetch Copilot review comments: `gh pr view <PR#> --json reviews,reviewThreads` or review on GitHub UI.
+    2. For each Copilot comment, draft a response with these fields:
+       - **What**: Copilot's feedback quoted or summarized.
+       - **Why**: Context of the code being reviewed.
+       - **Impact**: What would change if addressed (similar to mini-ADR).
        - **Recommendation**: One of:
-         - `Fix now` (with proposed diff)
-         - `Add to backlog` (with backlog item title + rationale)
-         - `Not applicable` (with reasoning)
+         - `Fix now` (with proposed diff).
+         - `Add to backlog` (with backlog item title + rationale).
+         - `Not applicable` (with reasoning).
     3. Present all responses to user sequentially (or as a batch table) for decision:
-       - **y** = approve recommendation
-       - **n** = decline recommendation (ask for alternative)
-       - **comment** = user feedback; revise recommendation
-    4. Accumulate approved responses
-    5. Implement approved "Fix now" items as part of retrospective (Phase 7)
-    6. Add approved "Add to backlog" items to ALL_SPRINTS_MASTER_PLAN.md
-    7. Post reply comments to Copilot threads explaining resolution
-  - **Model**: Requires Opus (review analysis -- see SPRINT_PLANNING.md "Activities Requiring Opus")
-  - **Skip condition**: If Copilot review is not enabled in repo, skip this step (document in retrospective that Copilot review was unavailable)
+       - **y** = approve recommendation.
+       - **n** = decline recommendation (ask for alternative).
+       - **comment** = user feedback; revise recommendation.
+    4. Accumulate approved responses.
+    5. Implement approved "Fix now" items as part of retrospective (Phase 7).
+    6. Add approved "Add to backlog" items to ALL_SPRINTS_MASTER_PLAN.md.
+    7. Post reply comments to Copilot threads explaining resolution.
+  - **Model**: Requires Opus (review analysis -- see SPRINT_PLANNING.md "Activities Requiring Opus").
+  - **Skip condition**: If Copilot review is not enabled in repo, skip this step (document in retrospective that Copilot review was unavailable).
 
 - [ ] **6.5 Notify User**
   - Inform user PR is ready for review


### PR DESCRIPTION
## Summary

Adds `.github/copilot-instructions.md` with custom instructions for GitHub Copilot code review.

- **File size**: 3,377 characters (under the 4,000-char hard limit Copilot uses for instruction files)
- **Structure**: Project context, flag categories (security, correctness, conventions, architecture, testing, PR hygiene), cross-cutting pattern sweep, de-emphasize list
- **Aligned with**: CLAUDE.md conventions + lessons from recent sprints (SEC-17 logging redaction, SEC-1 ReDoS protection, Sprint 32 Phase 5.1.1 code review process)

## Why

Sprint 32 Phase 6.4.1 introduced GitHub Copilot review as an additional code review layer. A repository custom instructions file lets Copilot focus on what matters for this project (security boundaries, conventions, architecture rules) and de-emphasize things already covered by `flutter analyze` / `dart format`.

## Sources

Best practices drawn from:
- GitHub Docs: Adding repository custom instructions
- GitHub Blog: Unlocking the full power of Copilot code review
- GitHub Community discussion on Copilot PR review instructions

Key constraints respected:
- 4,000-char hard limit (current file is 3,377)
- Base-branch read (file must be on develop for PR reviews to use it -- this PR merges it there)
- No external URLs (Copilot does not follow links; content is inlined)
- No unsupported formatting directives

## Test plan

- [x] File size under 4000 chars
- [ ] After merge: open a follow-up PR and verify Copilot applies the instructions (referenced file should appear in Copilot review output)

This is a docs-only change. No code affected.