### PR TITLE
Sprint 53 post-cert closeout: 0.5.9.0 LIVE, dev bump 0.5.10

### DIFF
--- a/.claude/sprint_status.json
+++ b/.claude/sprint_status.json
@@ -1,21 +1,21 @@
 {
   "_description": "Sprint status file that persists across context compaction. Update after each phase/sub-phase completion.",
-  "_last_updated": "2026-08-03T04:10:00Z",
+  "_last_updated": "2026-08-03T13:00:00Z",
   "_usage": "Read this file after context compaction to restore sprint approval state and progress.",
   "_staleness_note": "This file had drifted 15 sprints (last updated at Sprint 35, 2026-04-19) before being refreshed at Sprint 50 close-out. It is a Phase 7.7 checklist item -- update it at every sprint close-out, not opportunistically.",
 
   "current_sprint": {
     "number": 53,
     "branch": "feature/20260803_Sprint_53",
-    "pr_number": null,
-    "pr_url": null,
+    "pr_number": 295,
+    "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/295",
     "start_date": "2026-08-03",
-    "status": "Phase 1 -- awaiting Backlog Refinement. Branch opened via Phase 6.6 immediately after PR #292 merged; no task work has started. Do NOT create issue cards or task commits before Phase 3.7 plan approval -- require-sprint-cards.ps1 will block them anyway.",
-    "plan_approved": false,
-    "plan_approval_date": null,
-    "blanket_execution_approved": false,
-    "scope": [],
-    "_scope_note": "Not yet selected. Backlog Refinement is next."
+    "status": "PR #295 merged -> develop, PR #296 merged develop -> main (both 2026-08-03). F-STORE-53 smoke test complete and passed. Store MSIX 0.5.9.0 built from main, verified, uploaded to Partner Center as Submission 10, submitted for certification 2026-08-03 -- IN CERTIFICATION as of last check. Awaiting certification result before Phase 7 close-out.",
+    "plan_approved": true,
+    "plan_approval_date": "2026-08-03",
+    "blanket_execution_approved": true,
+    "scope": ["F-STORE-53: build + smoke-test-verify release-candidate MSIX, then (once smoke test passed) build the real Store MSIX and submit to Partner Center", "F138 closed (icons not needed)", "secrets.dev.json cleanup (prod worktree, gitignored)", "F139 + F140 added to backlog (surfaced live during F-STORE-53)"],
+    "_scope_note": "Single-task release sprint. Scope was corrected mid-sprint (Harold: 'this task is meant to be a smoke test, correct?') to exclude the merge/upload/certification steps from the TASK CARD -- those happened afterward as a separate, later, Harold-initiated action once the smoke pass had passed."
   },
 
   "previous_sprint": {
@@ -32,8 +32,8 @@
     "_review_depth_note": "Sprint 52 went through FOUR review rounds before merge (Copilot, then 3 multi-agent rounds), each finding real defects the previous round missed or introduced -- MV-1 (Accounts icon reaching nothing), diverged platform-inference logic across 3 copies (contains() vs endsWith()), a legacy-account regression from the round-2 fix, cache-staleness in a round-3 fix, and a zero-test-coverage function hit by 3 consecutive rounds. Worth referencing if a future sprint's review cadence is being scoped."
   },
 
-  "github_issues": [],
-  "_github_issues_note": "EMPTY -- Sprint 53 has no cards yet; created when scope is selected at Phase 3 (require-sprint-cards.ps1 blocks task commits until then). Sprint 52's three cards (#289/#290/#291) were closed BY HAND at Post-Merge Cleanup on 2026-08-03 and verified with `gh issue list --label sprint --state open` returning empty. `Closes #N` does NOT auto-fire in this GitFlow repo: PRs merge feature -> develop, and GitHub only auto-closes on merge to the DEFAULT branch.",
+  "github_issues": [294],
+  "_github_issues_note": "Issue #294 (F-STORE-53) created at Phase 3.3.1. Confirmed the standing GitFlow caveat held again: PR #295's 'Closes #294' did NOT auto-close it on merge to develop (gh issue view 294 showed OPEN after both #295 and #296 merged) -- closed by hand 2026-08-03 with a resolution comment, same pattern as Sprint 52's #289/#290/#291. This array tracks cards CREATED this sprint, not cards currently open -- #294 stays listed here even though it is now closed.",
 
   "test_metrics": {
     "tests_passing": 1859,
@@ -52,26 +52,23 @@
     "live_version": "0.5.8",
     "live_submission_number": 9,
     "previous_live_version": "0.5.7",
-    "submitted_version": "0.5.8",
-    "submission_number": 9,
-    "built_at": "2026-07-27",
-    "submitted_at": "2026-07-28",
-    "certified_at": "2026-07-29",
-    "status": "LIVE in the Microsoft Store",
-    "certification_evidence": "Partner Center 2026-07-29: 'Congrats! Your product is now updated. Your latest product is now available on Microsoft Store.' Store presence advanced Submission 8 -> Submission 9.",
+    "submitted_version": "0.5.9",
+    "submission_number": 10,
+    "built_at": "2026-08-03",
+    "submitted_at": "2026-08-03",
+    "certified_at": null,
+    "status": "IN CERTIFICATION (Submission 10). Pipeline stage at last check: Submission [done] -> Pre-processing [in progress] -> Certification [pending] -> Publishing [pending]. Do NOT treat as live until Partner Center shows a certified/published state -- see the 2026-07-28 BUILT+VALIDATED-is-not-SUBMITTED lesson below; the equivalent risk here is treating SUBMITTED as CERTIFIED.",
+    "certification_evidence": "Partner Center screenshot, Harold, 2026-08-03: product overview shows 'Update in certification' badge; Product update panel reads 'Submission 10: Last modified on 08/03/2026'.",
     "artifact": "D:\\Data\\Harold\\github\\spamfilter-multi-prod\\mobile-app\\build\\windows\\x64\\runner\\Release\\my_email_spam_filter.msix",
-    "verification": "both-sides proof passed (APP_ENV=prod AND NATIVE_APP_ENV=prod); manifest 0.5.8.0; 16.8 MB; credentials verified embedded in data/app.so. Partner Center confirms package Validated, v0.5.8.0, X64, Windows.Desktop min 10.0.17763.0.",
-    "_correction_2026_07_28": "This block previously read submitted_at 2026-07-27 / status 'in certification' with an expected result of 2026-07-28. That was WRONG. Partner Center showed Submission 9 sitting 'In draft' with a live 'Submit for certification' button -- the package was built and Validated on 07-27 but the submission was never pushed over the line. Store presence was still Submission 8 (0.5.7). Harold submitted it 2026-07-28 after checking Partner Center directly. LESSON: BUILT + VALIDATED is not SUBMITTED. This file recorded an intent as an accomplished fact and it was then repeated back as fact for a full day, including as a candidate explanation for an unrelated Store client bug. Verify release state in Partner Center, never from this file alone.",
-    "post_cert_closeout_done": [
-      "DONE 2026-07-30: CHANGELOG '## [0.5.8] - 2026-07-29' release heading + comparison links added",
-      "DONE 2026-07-30: dev bumped 0.5.8 -> 0.5.9 (ONE file, pubspec.yaml -- the F-VERSION-DERIVE payoff; version_consistency gate green)",
-      "DONE 2026-07-30: ALL_SPRINTS_MASTER_PLAN Store status -> LIVE; Last Completed Sprint rolled 50 -> 51",
-      "DONE 2026-07-30 (Harold, Store-installed build): NO [DEV] in the window title. This is the definitive end of the F119 FAMILY -- F119 (msix key typo `build_windows_args`), F119-b (space in a secrets.prod.json key silently dropping APP_ENV=prod), and F119-c (native SPAMFILTER_APP_ENV never set by the msix path, so CMake defaulted to dev). All three presented as the SAME user-visible symptom -- a [DEV] title on a Store build -- and took three sprints to fully clear. 0.5.8 is the first Store release verified clean by direct observation of the installed build."
-    ],
+    "verification": "Pre-upload: build log shows correct prod dart-defines (APP_ENV=prod, secrets.prod.json); manifest Version=0.5.9.0; size 16.80 MB (matches the RC build built earlier same day for the F-STORE-53 smoke test, byte-identical source). Smoke test (separate release-candidate build, self-signed for local install, NOT this artifact): --print-env clean (APP_ENV=prod, NATIVE_APP_ENV=prod, no dev suffixes), title bar clean, About screen + Gmail sign-in confirmed by Harold.",
     "post_cert_closeout_pending": [
-      "Harold to confirm the remaining TWO parts of the Store-install check when convenient (NOT yet reported, deliberately not assumed from the title result): (a) About screen shows 'Version 0.5.8' with no [DEV] suffix, (b) Gmail sign-in works -- the credential-embedding check, which is what F119 originally broke. The title being clean proves APP_ENV/NATIVE_APP_ENV resolved to prod; it does NOT prove the OAuth credentials were embedded, because those are separate dart-defines. Only a real sign-in proves that."
+      "Once Submission 10 certifies: update docs/STORE_VERSION_STATUS.md Live row to 0.5.9.0 (do not do this before certification actually completes)",
+      "Once certified: CHANGELOG.md -- add '## [0.5.9] - <cert-date>' release heading + comparison links (Unreleased entries already assembled)",
+      "Once certified: docs/ALL_SPRINTS_MASTER_PLAN.md -- Store status -> LIVE 0.5.9.0; roll Last Completed Sprint 52 -> 53",
+      "Once certified: dev bump 0.5.9 -> 0.5.10 (pubspec.yaml top-level version + msix_version, one commit, version_consistency gate green) -- per ADR-0035 patch+1 convention",
+      "Harold: confirm no [DEV] artifacts on the ACTUAL Store-installed (not self-signed RC) build once it publishes, same as every prior release -- the RC smoke test is a strong predictor but the Store-signed artifact has never been directly observed installed until it publishes"
     ],
-    "_closeout_sequencing_note": "These are RELEASE close-out steps, not Sprint 51 task work. The dev version bump in particular changes what every version-consistency gate asserts, so it should land as its own commit rather than mixed into sprint changes. Harold's Store-install verification is the only one Claude cannot do."
+    "_prior_release_history": "0.5.8 (Submission 9): built 2026-07-27, submitted 2026-07-28 (after a BUILT+VALIDATED-is-not-SUBMITTED near-miss -- see docs/sprints/SPRINT_51_SUMMARY.md), certified 2026-07-29, Harold-verified clean (no [DEV] title) 2026-07-30. Full both-sides proof (APP_ENV=prod AND NATIVE_APP_ENV=prod) passed for the first time on this release, closing the 3-sprint F119 family (F119 msix-key typo, F119-b secrets space-key, F119-c native env var never set)."
   },
 
   "environment_notes": [
@@ -82,9 +79,10 @@
   "blocking_issues": [],
 
   "next_actions": [
-    "SPRINT 53 Phase 1: BACKLOG REFINEMENT -- read the authoritative presentation format in docs/BACKLOG_REFINEMENT.md FIRST, then present candidates to Harold for scope selection. This is where Sprint 53 starts; no task work before Phase 3.7 approval.",
-    "HAROLD (release, low priority, not blocking): confirm the remaining Store-install checks -- About shows 'Version 0.5.8', and Gmail sign-in WORKS. The clean title proves APP_ENV/NATIVE_APP_ENV resolved to prod; only a real sign-in proves the OAuth credentials were embedded, which is what F119 originally broke.",
-    "HAROLD (release, when ready): develop -> main merge for the Sprint 52 work, once ready for a Store release cycle.",
+    "WAIT for Submission 10 (0.5.9.0) certification result in Partner Center -- typically a few hours, up to 3 business days per Microsoft. Do not assume certified; check Partner Center directly.",
+    "ON CERTIFICATION: run the post_cert_closeout_pending list in store_release above (STORE_VERSION_STATUS.md Live row, CHANGELOG [0.5.9] heading, master-plan Store status + Last Completed Sprint roll, dev bump 0.5.9 -> 0.5.10).",
+    "ON CERTIFICATION: Harold to confirm the actual Store-installed 0.5.9.0 build shows no [DEV] artifacts -- the RC smoke test already passed, but the Store-signed artifact itself has not been directly observed installed yet.",
+    "AFTER post-cert closeout: Sprint 53 Phase 7 retrospective (14 categories x 4 roles) -- has not yet been run.",
     "Android/Google Play remains the next major track (promotion trigger fired 2026-07-24)"
   ]
 }

--- a/.claude/sprint_status.json
+++ b/.claude/sprint_status.json
@@ -1,35 +1,34 @@
 {
   "_description": "Sprint status file that persists across context compaction. Update after each phase/sub-phase completion.",
-  "_last_updated": "2026-08-03T13:00:00Z",
+  "_last_updated": "2026-08-03T14:30:00Z",
   "_usage": "Read this file after context compaction to restore sprint approval state and progress.",
   "_staleness_note": "This file had drifted 15 sprints (last updated at Sprint 35, 2026-04-19) before being refreshed at Sprint 50 close-out. It is a Phase 7.7 checklist item -- update it at every sprint close-out, not opportunistically.",
 
   "current_sprint": {
+    "number": 54,
+    "branch": null,
+    "pr_number": null,
+    "pr_url": null,
+    "start_date": null,
+    "status": "NOT YET OPENED. Sprint 53 closed 2026-08-03 (retro skipped by PO decision). Next sprint's branch/scope selection has not started -- Backlog Refinement is the next step whenever work resumes.",
+    "plan_approved": false,
+    "plan_approval_date": null,
+    "blanket_execution_approved": false,
+    "scope": [],
+    "_scope_note": "Not yet selected."
+  },
+
+  "previous_sprint": {
     "number": 53,
     "branch": "feature/20260803_Sprint_53",
     "pr_number": 295,
     "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/295",
-    "start_date": "2026-08-03",
-    "status": "PR #295 merged -> develop, PR #296 merged develop -> main (both 2026-08-03). F-STORE-53 smoke test complete and passed. Store MSIX 0.5.9.0 built from main, verified, uploaded to Partner Center as Submission 10, submitted for certification 2026-08-03 -- IN CERTIFICATION as of last check. Awaiting certification result before Phase 7 close-out.",
-    "plan_approved": true,
-    "plan_approval_date": "2026-08-03",
-    "blanket_execution_approved": true,
-    "scope": ["F-STORE-53: build + smoke-test-verify release-candidate MSIX, then (once smoke test passed) build the real Store MSIX and submit to Partner Center", "F138 closed (icons not needed)", "secrets.dev.json cleanup (prod worktree, gitignored)", "F139 + F140 added to backlog (surfaced live during F-STORE-53)"],
-    "_scope_note": "Single-task release sprint. Scope was corrected mid-sprint (Harold: 'this task is meant to be a smoke test, correct?') to exclude the merge/upload/certification steps from the TASK CARD -- those happened afterward as a separate, later, Harold-initiated action once the smoke pass had passed."
-  },
-
-  "previous_sprint": {
-    "number": 52,
-    "branch": "feature/20260730_Sprint_52",
-    "pr_number": 292,
-    "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/292",
     "merged_at": "2026-08-03",
-    "merge_commit": "dfe8f89e37e1d3bf171bf5d7e2b57c43355ec674",
-    "merge_note": "PR #292 -> develop. Post-Merge Cleanup COMPLETE: Sprint 53 branch opened from the Sprint 52 branch, issues #289/#290/#291 closed by hand with resolution notes (gh issue list --label sprint --state open verified EMPTY), all sprint branches retained.",
+    "merge_note": "PR #295 -> develop, PR #296 (develop -> main) both merged 2026-08-03. Issue #294 closed by hand (Closes-on-merge-to-develop does not auto-fire in this GitFlow repo). Retrospective SKIPPED by explicit Product Owner decision (Harold, 2026-08-03: 'PO approves skipping sprint 53 retrospective') -- deliberate exception, not an oversight, for this single-task release sprint.",
     "status": "complete",
-    "deliverables": ["F133-S52 accessibility audit (all 27 screens) + full remediation", "F131 WinWright root cause (selector bug, not an app defect)", "F134 + F134-ALL canonical AppBar order (all screens)", "F135 session-scoped account selection + lazy Settings resolution", "F136 Skip button", "6 retrospective improvements (IMP-1..6)"],
-    "verification": "1,859 tests passed / 29 skipped / 0 failed (from 1,815 at Sprint 51 close); analyze clean; hook suite 45/45; Manual Validation closed by Harold; Copilot review + 3 further multi-agent review rounds, all findings fixed",
-    "_review_depth_note": "Sprint 52 went through FOUR review rounds before merge (Copilot, then 3 multi-agent rounds), each finding real defects the previous round missed or introduced -- MV-1 (Accounts icon reaching nothing), diverged platform-inference logic across 3 copies (contains() vs endsWith()), a legacy-account regression from the round-2 fix, cache-staleness in a round-3 fix, and a zero-test-coverage function hit by 3 consecutive rounds. Worth referencing if a future sprint's review cadence is being scoped."
+    "deliverables": ["F-STORE-53: release-candidate smoke test (passed) then real Store MSIX 0.5.9.0 built, uploaded, and CERTIFIED + LIVE as Submission 10", "F138 closed (icons not needed in rule-editing-screen context)", "secrets.dev.json cleanup (prod worktree, gitignored, no commit)", "F139 + F140 added to backlog (local-install smoke test template; WinWright end-of-page reachability gap)", "dev bumped 0.5.9 -> 0.5.10 (pubspec.yaml, gate-verified)"],
+    "verification": "Pre-build: 1,859 tests passed / 29 skipped / 0 failed, analyze clean. Store build: manifest 0.5.9.0, 16.80 MB, correct prod dart-defines. Smoke test (RC build): --print-env clean, title bar clean, Harold-confirmed Gmail sign-in + About screen clean.",
+    "_no_retro_note": "Because the retrospective was skipped, there is no Category 1-14 x 4-role feedback to carry forward and no docs/sprints/SPRINT_53_RETROSPECTIVE.md. Only SPRINT_53_PLAN.md exists for this sprint's docs."
   },
 
   "github_issues": [294],
@@ -49,40 +48,42 @@
 
   "store_release": {
     "_see_also": "docs/STORE_VERSION_STATUS.md is the quick-check summary (live Store version + current dev version, both with a last-verified date). This block is the working detail behind that summary. Keep both in sync; STORE_VERSION_STATUS.md is what to open for a fast answer, this block is where the evidence lives.",
-    "live_version": "0.5.8",
-    "live_submission_number": 9,
-    "previous_live_version": "0.5.7",
+    "live_version": "0.5.9",
+    "live_submission_number": 10,
+    "previous_live_version": "0.5.8",
     "submitted_version": "0.5.9",
     "submission_number": 10,
     "built_at": "2026-08-03",
     "submitted_at": "2026-08-03",
-    "certified_at": null,
-    "status": "IN CERTIFICATION (Submission 10). Pipeline stage at last check: Submission [done] -> Pre-processing [in progress] -> Certification [pending] -> Publishing [pending]. Do NOT treat as live until Partner Center shows a certified/published state -- see the 2026-07-28 BUILT+VALIDATED-is-not-SUBMITTED lesson below; the equivalent risk here is treating SUBMITTED as CERTIFIED.",
-    "certification_evidence": "Partner Center screenshot, Harold, 2026-08-03: product overview shows 'Update in certification' badge; Product update panel reads 'Submission 10: Last modified on 08/03/2026'.",
+    "certified_at": "2026-08-03",
+    "status": "CERTIFIED + LIVE in the Microsoft Store.",
+    "certification_evidence": "Partner Center screenshot, Harold, 2026-08-03: Application overview -> 'Store presence (Submission 10)' section shows the green 'Your product is currently available in the Microsoft Store' confirmation. Submission 11 auto-opened as the next draft slot (normal behavior, same v0.5.9.0 package shown 'Unchanged') -- not a new release in progress.",
     "artifact": "D:\\Data\\Harold\\github\\spamfilter-multi-prod\\mobile-app\\build\\windows\\x64\\runner\\Release\\my_email_spam_filter.msix",
     "verification": "Pre-upload: build log shows correct prod dart-defines (APP_ENV=prod, secrets.prod.json); manifest Version=0.5.9.0; size 16.80 MB (matches the RC build built earlier same day for the F-STORE-53 smoke test, byte-identical source). Smoke test (separate release-candidate build, self-signed for local install, NOT this artifact): --print-env clean (APP_ENV=prod, NATIVE_APP_ENV=prod, no dev suffixes), title bar clean, About screen + Gmail sign-in confirmed by Harold.",
+    "_client_propagation_lag_2026_08_03": "Same day as certification, BOTH the Store app's own product-detail page (renders as skeleton placeholders, identical symptom to the 2026-07-28 known bug logged in environment_notes) AND `winget upgrade`/`winget install --source msstore` (reports 'No available upgrade found', `winget show` reports Version: Unknown) lagged behind the certified state. `winget source update` was run and did not fix it -- the msstore catalog itself is a Microsoft-hosted index outside local control. Partner Center's Store-presence confirmation is authoritative regardless of what these client-side surfaces report; no further action needed beyond waiting for propagation. Not a submission defect -- do not re-diagnose as one.",
+    "post_cert_closeout_done": [
+      "DONE 2026-08-03: docs/STORE_VERSION_STATUS.md Live row updated to 0.5.9.0 + client-propagation-lag note added",
+      "DONE 2026-08-03: CHANGELOG.md -- added post-cert closeout entry + '## [0.5.9] - 2026-08-03' release heading + comparison note (Sprint 51/52/53 entries now under it)",
+      "DONE 2026-08-03: docs/ALL_SPRINTS_MASTER_PLAN.md -- Store status -> LIVE 0.5.9.0; Last Completed Sprint rolled 52 -> 53; Past Sprint Summary table updated (also backfilled the missing Sprint 52 row)",
+      "DONE 2026-08-03: dev bumped 0.5.9 -> 0.5.10 (pubspec.yaml top-level version ONLY -- msix_version deliberately left at 0.5.9.0 until the next release build, per the F139 lesson about premature/stale bumps); version_consistency gate green"
+    ],
     "post_cert_closeout_pending": [
-      "Once Submission 10 certifies: update docs/STORE_VERSION_STATUS.md Live row to 0.5.9.0 (do not do this before certification actually completes)",
-      "Once certified: CHANGELOG.md -- add '## [0.5.9] - <cert-date>' release heading + comparison links (Unreleased entries already assembled)",
-      "Once certified: docs/ALL_SPRINTS_MASTER_PLAN.md -- Store status -> LIVE 0.5.9.0; roll Last Completed Sprint 52 -> 53",
-      "Once certified: dev bump 0.5.9 -> 0.5.10 (pubspec.yaml top-level version + msix_version, one commit, version_consistency gate green) -- per ADR-0035 patch+1 convention",
-      "Harold: confirm no [DEV] artifacts on the ACTUAL Store-installed (not self-signed RC) build once it publishes, same as every prior release -- the RC smoke test is a strong predictor but the Store-signed artifact has never been directly observed installed until it publishes"
+      "Harold: confirm the actual Store-installed 0.5.9.0 build (once winget/Store client propagation catches up and it can be freshly installed/updated) shows no [DEV] artifacts -- the RC smoke test is a strong predictor but the Store-signed artifact itself has not yet been directly observed installed via winget/Store client"
     ],
     "_prior_release_history": "0.5.8 (Submission 9): built 2026-07-27, submitted 2026-07-28 (after a BUILT+VALIDATED-is-not-SUBMITTED near-miss -- see docs/sprints/SPRINT_51_SUMMARY.md), certified 2026-07-29, Harold-verified clean (no [DEV] title) 2026-07-30. Full both-sides proof (APP_ENV=prod AND NATIVE_APP_ENV=prod) passed for the first time on this release, closing the 3-sprint F119 family (F119 msix-key typo, F119-b secrets space-key, F119-c native env var never set)."
   },
 
   "environment_notes": [
     "RESOLVED 2026-07-29 (verified 07-30): the Store fault was an Acronis file-system filter blocking AppXSvc cleanup, fixed by an Acronis Protection exclusion. 23h uptime with ZERO Id-493 events vs a 176-file/6-min baseline; Store client self-updated 22606.1401.6.0 -> .10.0 (requires a working deployment pipeline). Filter drivers remain loaded -- backup protection was NOT disabled. See ALL_SPRINTS_MASTER_PLAN ENV-1 for the picker gotcha if it recurs.",
-    "Microsoft Store CLIENT bug (observed 2026-07-28, NOT ours, NOT blocking): app DETAIL pages render as skeleton placeholders that never populate, then blank. Search results render fine (12 apps with icons/ratings/screenshots, ours correctly marked Installed), and app icon + title + rating load on the detail page -- only the live-fetched content fails. Reproduces on THIRD-PARTY listings (Spike Email), so it is not our listing or our package. Survived Store restart, full reboot, and wsreset.exe. No action available beyond awaiting a Store client update. Do NOT re-diagnose this as an app or submission defect: the third-party reproduction is the decisive evidence."
+    "Microsoft Store CLIENT bug (observed 2026-07-28, NOT ours, NOT blocking): app DETAIL pages render as skeleton placeholders that never populate, then blank. Search results render fine (12 apps with icons/ratings/screenshots, ours correctly marked Installed), and app icon + title + rating load on the detail page -- only the live-fetched content fails. Reproduces on THIRD-PARTY listings (Spike Email), so it is not our listing or our package. Survived Store restart, full reboot, and wsreset.exe. No action available beyond awaiting a Store client update. Do NOT re-diagnose this as an app or submission defect: the third-party reproduction is the decisive evidence.",
+    "RECURRED 2026-08-03 (0.5.9.0 certification day): the same Store-detail-page skeleton symptom reproduced immediately, PLUS winget's msstore catalog independently lagged (winget show reported Version: Unknown, winget upgrade/install reported 'No available upgrade found' even after `winget source update`). Partner Center's Store-presence section was the only surface confirming the release was actually live. This is now a recurring pattern on certification day specifically -- client-side propagation (Store app cache, winget's msstore catalog mirror) lags Partner Center's own confirmation by some hours. Treat Partner Center as authoritative every time; do not wait for winget/Store client agreement before considering a release live."
   ],
 
   "blocking_issues": [],
 
   "next_actions": [
-    "WAIT for Submission 10 (0.5.9.0) certification result in Partner Center -- typically a few hours, up to 3 business days per Microsoft. Do not assume certified; check Partner Center directly.",
-    "ON CERTIFICATION: run the post_cert_closeout_pending list in store_release above (STORE_VERSION_STATUS.md Live row, CHANGELOG [0.5.9] heading, master-plan Store status + Last Completed Sprint roll, dev bump 0.5.9 -> 0.5.10).",
-    "ON CERTIFICATION: Harold to confirm the actual Store-installed 0.5.9.0 build shows no [DEV] artifacts -- the RC smoke test already passed, but the Store-signed artifact itself has not been directly observed installed yet.",
-    "AFTER post-cert closeout: Sprint 53 Phase 7 retrospective (14 categories x 4 roles) -- has not yet been run.",
+    "Harold: once winget/Store client propagation catches up, confirm the actual Store-installed 0.5.9.0 build shows no [DEV] artifacts (About screen, title bar) -- see store_release.post_cert_closeout_pending.",
+    "SPRINT 54: not yet opened. Backlog Refinement is the next step whenever work resumes -- read docs/BACKLOG_REFINEMENT.md's presentation format first.",
     "Android/Google Play remains the next major track (promotion trigger fired 2026-07-24)"
   ]
 }

--- a/.claude/sprint_status.json
+++ b/.claude/sprint_status.json
@@ -1,34 +1,35 @@
 {
   "_description": "Sprint status file that persists across context compaction. Update after each phase/sub-phase completion.",
-  "_last_updated": "2026-08-03T14:30:00Z",
+  "_last_updated": "2026-08-03T14:45:00Z",
   "_usage": "Read this file after context compaction to restore sprint approval state and progress.",
   "_staleness_note": "This file had drifted 15 sprints (last updated at Sprint 35, 2026-04-19) before being refreshed at Sprint 50 close-out. It is a Phase 7.7 checklist item -- update it at every sprint close-out, not opportunistically.",
 
   "current_sprint": {
-    "number": 54,
-    "branch": null,
-    "pr_number": null,
-    "pr_url": null,
-    "start_date": null,
-    "status": "NOT YET OPENED. Sprint 53 closed 2026-08-03 (retro skipped by PO decision). Next sprint's branch/scope selection has not started -- Backlog Refinement is the next step whenever work resumes.",
-    "plan_approved": false,
-    "plan_approval_date": null,
-    "blanket_execution_approved": false,
-    "scope": [],
-    "_scope_note": "Not yet selected."
+    "number": 53,
+    "branch": "feature/20260803_Sprint_53",
+    "pr_number": 297,
+    "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/297",
+    "start_date": "2026-08-03",
+    "status": "Phase 7 complete (retro SKIPPED by explicit PO decision, Harold 2026-08-03). Sprint 53's F-STORE-53 task is done, 0.5.9.0 is CERTIFIED + LIVE. Follow-up PR #297 (post-cert closeout: CHANGELOG heading, master-plan roll, dev version bump) is open on this same branch, targeting develop, awaiting Harold's merge -- this is past Manual Validation, outside the sprint-auto-advance enforcement window. Sprint 54 has not been opened yet; that starts once #297 merges and Phase 6.6 carry-forward runs.",
+    "plan_approved": true,
+    "plan_approval_date": "2026-08-03",
+    "blanket_execution_approved": true,
+    "scope": ["F-STORE-53: build + smoke-test-verify release-candidate MSIX, then build the real Store MSIX and submit to Partner Center", "F138 closed (icons not needed)", "secrets.dev.json cleanup (prod worktree, gitignored)", "F139 + F140 added to backlog", "post-cert closeout (PR #297)"],
+    "_scope_note": "Sprint 53 complete. Kept as current_sprint (rather than rolled to previous_sprint) until PR #297 actually merges, so the branch this session is on matches what the status file names as current."
   },
 
   "previous_sprint": {
-    "number": 53,
-    "branch": "feature/20260803_Sprint_53",
-    "pr_number": 295,
-    "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/295",
+    "number": 52,
+    "branch": "feature/20260730_Sprint_52",
+    "pr_number": 292,
+    "pr_url": "https://github.com/kimmeyh/spamfilter-multi/pull/292",
     "merged_at": "2026-08-03",
-    "merge_note": "PR #295 -> develop, PR #296 (develop -> main) both merged 2026-08-03. Issue #294 closed by hand (Closes-on-merge-to-develop does not auto-fire in this GitFlow repo). Retrospective SKIPPED by explicit Product Owner decision (Harold, 2026-08-03: 'PO approves skipping sprint 53 retrospective') -- deliberate exception, not an oversight, for this single-task release sprint.",
+    "merge_commit": "dfe8f89e37e1d3bf171bf5d7e2b57c43355ec674",
+    "merge_note": "PR #292 -> develop. Post-Merge Cleanup COMPLETE: Sprint 53 branch opened from the Sprint 52 branch, issues #289/#290/#291 closed by hand with resolution notes (gh issue list --label sprint --state open verified EMPTY), all sprint branches retained.",
     "status": "complete",
-    "deliverables": ["F-STORE-53: release-candidate smoke test (passed) then real Store MSIX 0.5.9.0 built, uploaded, and CERTIFIED + LIVE as Submission 10", "F138 closed (icons not needed in rule-editing-screen context)", "secrets.dev.json cleanup (prod worktree, gitignored, no commit)", "F139 + F140 added to backlog (local-install smoke test template; WinWright end-of-page reachability gap)", "dev bumped 0.5.9 -> 0.5.10 (pubspec.yaml, gate-verified)"],
-    "verification": "Pre-build: 1,859 tests passed / 29 skipped / 0 failed, analyze clean. Store build: manifest 0.5.9.0, 16.80 MB, correct prod dart-defines. Smoke test (RC build): --print-env clean, title bar clean, Harold-confirmed Gmail sign-in + About screen clean.",
-    "_no_retro_note": "Because the retrospective was skipped, there is no Category 1-14 x 4-role feedback to carry forward and no docs/sprints/SPRINT_53_RETROSPECTIVE.md. Only SPRINT_53_PLAN.md exists for this sprint's docs."
+    "deliverables": ["F133-S52 accessibility audit (all 27 screens) + full remediation", "F131 WinWright root cause (selector bug, not an app defect)", "F134 + F134-ALL canonical AppBar order (all screens)", "F135 session-scoped account selection + lazy Settings resolution", "F136 Skip button", "6 retrospective improvements (IMP-1..6)"],
+    "verification": "1,859 tests passed / 29 skipped / 0 failed (from 1,815 at Sprint 51 close); analyze clean; hook suite 45/45; Manual Validation closed by Harold; Copilot review + 3 further multi-agent review rounds, all findings fixed",
+    "_review_depth_note": "Sprint 52 went through FOUR review rounds before merge (Copilot, then 3 multi-agent rounds), each finding real defects the previous round missed or introduced -- MV-1 (Accounts icon reaching nothing), diverged platform-inference logic across 3 copies (contains() vs endsWith()), a legacy-account regression from the round-2 fix, cache-staleness in a round-3 fix, and a zero-test-coverage function hit by 3 consecutive rounds. Worth referencing if a future sprint's review cadence is being scoped."
   },
 
   "github_issues": [294],
@@ -82,8 +83,9 @@
   "blocking_issues": [],
 
   "next_actions": [
+    "HAROLD: merge PR #297 (feature/20260803_Sprint_53 -> develop, post-cert closeout) when convenient, then develop -> main same as PR #295/#296.",
+    "ON MERGE: Phase 6.6 carry-forward -- open the Sprint 54 branch from feature/20260803_Sprint_53 immediately, then Backlog Refinement is Sprint 54's first step (read docs/BACKLOG_REFINEMENT.md's presentation format first).",
     "Harold: once winget/Store client propagation catches up, confirm the actual Store-installed 0.5.9.0 build shows no [DEV] artifacts (About screen, title bar) -- see store_release.post_cert_closeout_pending.",
-    "SPRINT 54: not yet opened. Backlog Refinement is the next step whenever work resumes -- read docs/BACKLOG_REFINEMENT.md's presentation format first.",
     "Android/Google Play remains the next major track (promotion trigger fired 2026-07-24)"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,19 @@ Format: `- **type**: Description (Issue #N)` where type is feat|fix|chore|docs
 
 ## [Unreleased]
 
+### 2026-08-03 (Sprint 53: post-certification closeout)
+- **chore**: Submission 10 (0.5.9.0) certified and published to the Microsoft Store 2026-08-03, confirmed via Partner Center's "Store presence" section. `winget upgrade`/the Store app's own product page lagged behind the certified state for a time (same client-side propagation-lag pattern documented 2026-07-28) -- Partner Center's Store-presence confirmation is authoritative regardless of what client-side surfaces report.
+- **docs**: F139 (HOLD template) -- local-install smoke test for a release-candidate MSIX: the Store-submission MSIX config (`store: true, install_certificate: false`) produces an unsigned package that cannot install locally; flipping to `store: false, install_certificate: true` self-signs a build for local testing, which installs side-by-side with the live Store build under a different package identity without disturbing it.
+- **docs**: F140 -- the app version display (Settings > General "About" section, and equivalent Help-screen content) sits at the end of a long scrollable single-page tab and could not be reached by WinWright/UIA automation during the F-STORE-53 smoke test (`ww_scroll` and direct element clicks both failed with `element_offscreen`). Backlogged: investigate a WinWright/Flutter-side fix, falling back to relocating the version display nearer the top of the page if that proves impractical.
+
 ### 2026-08-03 (Sprint 53: Store release prep)
 - **chore**: `msix_config.msix_version` bumped `0.5.8.0` -> `0.5.9.0`. This field had not been touched in Sprint 51 or 52 -- only `pubspec.yaml`'s top-level `version:` (which drives the runtime version via F-VERSION-DERIVE) had moved to `0.5.9+1` as a post-0.5.8-release step; `msix_version` is a separate field read only by the MSIX packaging step and was left stale. Caught while preparing the 0.5.9.0 Store submission.
 - **docs**: new `docs/STORE_VERSION_STATUS.md` -- a two-row quick-check cache of the current live/certified Store version and the current dev version, each with a last-verified date. Explicitly framed as a CACHE, not a source of truth: the live-Store fact can only be authoritative in Partner Center itself, and this file exists so nobody has to re-derive "what's live" from scattered notes -- while still requiring a direct Partner Center check before treating it as current. Wired into `STORE_RELEASE_PROCESS.md`'s Pre-Release Checklist (check + re-verify) and Step 7 (update on certification / dev bump), and cross-referenced from `sprint_status.json`'s `store_release` block so there is one clear hierarchy instead of three places that can each drift independently.
+
+## [0.5.9] - 2026-08-03
+
+Certified and LIVE in the Microsoft Store 2026-08-03 (Partner Center Submission 10). Contains the
+Sprint 51, 52, and Sprint 53 work below.
 
 ### 2026-08-02 (Sprint 52: manual-validation fixes + retrospective improvements)
 - **fix**: MV-1 -- the Accounts AppBar icon reached nothing on **every** screen. An intersection defect: F134 (canonical order) and F135 (No-Rule becomes the desktop default) were each correct alone, but the icon defaulted to `Navigator.popUntil(context, (route) => route.isFirst)`, which worked only while Account Selection was what the first route rendered. Once F135 made `MainNavigationScreen` render the No-Rule screen inline, Account Selection stopped being a route at all -- so from the No-Rule screen the icon did nothing, and from deeper screens it unwound to No-Rule. Now pushes `AccountSelectionScreen`; fixed once in the shared builder, so every screen got it (Issue #291)

--- a/docs/ALL_SPRINTS_MASTER_PLAN.md
+++ b/docs/ALL_SPRINTS_MASTER_PLAN.md
@@ -4,7 +4,7 @@
 
 **Audience**: Claude Code models planning sprints; User prioritizing future work
 
-**Last Updated**: 2026-07-30 (Sprint 51 retrospective complete: Manual Validation closed all 5 items; IMP-7 shipped in-sprint; **F133/F133-S52, F134, F135, F136 carded for Sprint 52 detail planning**, and **F132 RETIRED into F133**. **`0.5.8` is LIVE in the Store** -- certified 2026-07-29 as Submission 9. See Version History 6.19)
+**Last Updated**: 2026-08-03 (Sprint 53 F-STORE-53 complete: release-candidate smoke test passed, then the real Store MSIX built, uploaded, and certified. **`0.5.9` is LIVE in the Store** -- certified 2026-08-03 as Submission 10. F139 (local-install smoke test template) and F140 (WinWright end-of-page reachability) added to backlog. Dev bumped 0.5.9 -> 0.5.10 (pubspec.yaml, gate-verified).)
 
 ## How to Maintain This Document
 
@@ -116,12 +116,24 @@ Historical sprint information lives in individual documents in `docs/sprints/` a
 | 49 | docs/sprints/SPRINT_49_SUMMARY.md | [OK] Complete | Jul 21-23, 2026 (PR #276) |
 | 50 | docs/sprints/SPRINT_50_SUMMARY.md | [OK] Complete | Jul 25-27, 2026 (PR #278; 0.5.8 submitted) |
 | 51 | docs/sprints/SPRINT_51_SUMMARY.md | [OK] Complete | Jul 27-30, 2026 (PR #285; 0.5.8 LIVE Jul 29) |
+| 52 | docs/sprints/SPRINT_52_SUMMARY.md | [OK] Complete | Jul 30-Aug 2, 2026 (PR #292) |
+| 53 | docs/sprints/SPRINT_53_PLAN.md | [OK] Complete (retro skipped, PO decision) | Aug 3, 2026 (PR #295/#296; 0.5.9 LIVE Aug 3) |
 
 **Key Achievements**: See CHANGELOG.md for detailed feature history.
 
 ---
 
 ## Last Completed Sprint
+
+**Sprint 53** (2026-08-03; PR #295 -> develop, PR #296 -> main)
+- **Type**: Single-task Store release sprint. 1/1 task complete.
+- **Delivered**: **F-STORE-53** -- scope corrected mid-sprint from "full release pipeline" to "smoke test only" after Harold flagged scope creep ("this task is meant to be a smoke test, correct?"); release-candidate MSIX built locally (no merge required) and smoke-tested clean (Gmail sign-in, About screen, title bar, no `[DEV]` artifacts). Once the smoke test passed, the real Store MSIX 0.5.9.0 was built from `main`, verified, uploaded to Partner Center, and **CERTIFIED + LIVE 2026-08-03** as Submission 10. **F138** closed (icons not needed in the 5 rule-editing screens' context, Harold decision). Dev bumped 0.5.9 -> 0.5.10 (pubspec.yaml, one file, gate-verified).
+- **Backlog additions found live during the smoke test**: **F139** (HOLD template) -- the Store-submission MSIX config produces an unsigned package that cannot install locally; self-signing via `store: false, install_certificate: true` installs a release candidate side-by-side with the live Store build without disturbing it. **F140** -- the app version display on Settings > General and Help sits at the end of a long scrollable tab and could not be reached by WinWright/UIA automation (`ww_scroll`/direct-click both failed with `element_offscreen`); backlogged to investigate a fix or relocate the display nearer the top of the page.
+- **Verification**: pre-build suite 1,859 passed / 29 skipped / 0 failed, analyze clean (re-confirmed on the release-candidate build); Store-build manifest 0.5.9.0, 16.80 MB, correct prod dart-defines; Harold-confirmed Gmail sign-in + About screen + title bar clean on the smoke-test build.
+- **Retro**: **SKIPPED by explicit Product Owner decision** (Harold, 2026-08-03: "PO approves skipping sprint 53 retrospective") -- a deliberate exception to the Phase 7 completeness rule for this single-task release sprint, not an oversight.
+- **Docs**: SPRINT_53_PLAN.md.
+
+_(Prior: **Sprint 52** below.)_
 
 **Sprint 52** (2026-07-30 -- 2026-08-02; PR #292 -> develop)
 - **Type**: Accessibility audit + full remediation, AppBar consistency, account-selection UX. 7/7 tasks complete (5 planned + 2 added mid-sprint), plus 3 manual-validation fixes.

--- a/docs/STORE_VERSION_STATUS.md
+++ b/docs/STORE_VERSION_STATUS.md
@@ -17,13 +17,17 @@ Partner Center before saying anything about the Store version.
 
 | | Version | Last verified | Notes |
 |---|---|---|---|
-| **Live/certified on Store** (cache) | 0.5.8.0 | 2026-07-30 (Harold, Store-installed build) | Submission 9, certified 2026-07-29. **Submission 10 (0.5.9.0) is IN CERTIFICATION as of 2026-08-03** (Harold, Partner Center screenshot: Submission -> Pre-processing -> Certification -> Publishing pipeline, currently at Pre-processing). Update this row to 0.5.9.0 only once certification actually completes -- do not treat "submitted" as "live". |
-| **Dev worktree** (authoritative -- mirrors `pubspec.yaml`) | 0.5.9+1 | 2026-08-03 | `msix_version` bumped to `0.5.9.0` to match (Sprint 53) -- it had been left stale at `0.5.8.0` through Sprints 51-52. Built and submitted as Submission 10, 2026-08-03 (see Live row). |
+| **Live/certified on Store** (cache) | 0.5.9.0 | 2026-08-03 (Harold, Partner Center: Application overview shows "Store presence (Submission 10)" with the green "currently available in the Microsoft Store" confirmation) | Submission 10, certified and published 2026-08-03. Submission 11 auto-opened as the next draft slot (normal Partner Center behavior, not a new release in progress) -- shows the same v0.5.9.0 package "Unchanged". |
+| **Dev worktree** (authoritative -- mirrors `pubspec.yaml`) | 0.5.9+1 | 2026-08-03 | Matches the released version -- due for the post-cert patch+1 bump to `0.5.10` per ADR-0035 convention (Sprint 53 close-out). |
 
 ## Update this file every time
 
 - **A Store submission certifies** -- update the Store row: version, date verified, submission number, and who/how it was verified (Partner Center screenshot, installed-build check, etc.).
 - **`pubspec.yaml`'s top-level `version:` changes** -- update the Dev row to match. This should be nearly automatic since it is a direct mirror; if this row and `pubspec.yaml` ever disagree, `pubspec.yaml` wins and this file is wrong.
+
+## Known client-side propagation lag (not our defect)
+
+After a submission certifies and Partner Center confirms it live, the Store app UI (product detail page renders as skeleton placeholders, same as the 2026-07-28 incident -- reproduces on third-party listings too) and `winget upgrade`/`winget install --source msstore` (reports "No available upgrade found" even though Partner Center confirms the new version is live) can both lag behind the actual certified state. This happened again on the 0.5.9.0 release (2026-08-03), same day as certification. Partner Center's "Store presence" section is the authoritative signal -- if it shows the product "currently available" at the target version, treat it as live regardless of what the Store client or winget currently report. No action needed beyond waiting for client-side caches to refresh.
 
 ## Related
 

--- a/docs/STORE_VERSION_STATUS.md
+++ b/docs/STORE_VERSION_STATUS.md
@@ -17,8 +17,8 @@ Partner Center before saying anything about the Store version.
 
 | | Version | Last verified | Notes |
 |---|---|---|---|
-| **Live/certified on Store** (cache) | 0.5.8.0 | 2026-07-30 (Harold, Store-installed build) | Submission 9, certified 2026-07-29. |
-| **Dev worktree** (authoritative -- mirrors `pubspec.yaml`) | 0.5.9+1 | 2026-08-03 | Not yet released. `msix_version` bumped to `0.5.9.0` to match (Sprint 53) -- it had been left stale at `0.5.8.0` through Sprints 51-52. This is the release currently in progress. |
+| **Live/certified on Store** (cache) | 0.5.8.0 | 2026-07-30 (Harold, Store-installed build) | Submission 9, certified 2026-07-29. **Submission 10 (0.5.9.0) is IN CERTIFICATION as of 2026-08-03** (Harold, Partner Center screenshot: Submission -> Pre-processing -> Certification -> Publishing pipeline, currently at Pre-processing). Update this row to 0.5.9.0 only once certification actually completes -- do not treat "submitted" as "live". |
+| **Dev worktree** (authoritative -- mirrors `pubspec.yaml`) | 0.5.9+1 | 2026-08-03 | `msix_version` bumped to `0.5.9.0` to match (Sprint 53) -- it had been left stale at `0.5.8.0` through Sprints 51-52. Built and submitted as Submission 10, 2026-08-03 (see Live row). |
 
 ## Update this file every time
 

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: my_email_spam_filter
 description: Cross-platform email spam filter app
-version: 0.5.9+1
+version: 0.5.10+1
 publish_to: 'none'
 
 environment:


### PR DESCRIPTION
## Summary

Post-certification closeout for the Sprint 53 Store release (PR #295/#296, already merged). Submission 10 (0.5.9.0) certified and went LIVE 2026-08-03; this PR carries the closeout bookkeeping that could only happen after certification completed.

## Changes

- CHANGELOG.md: `[0.5.9]` release heading added, Sprint 51/52/53 entries now ship under it
- docs/STORE_VERSION_STATUS.md: Live row -> 0.5.9.0; new section documenting a recurring winget/Store-client propagation-lag pattern on certification day
- docs/ALL_SPRINTS_MASTER_PLAN.md: Last Completed Sprint rolled 52 -> 53 (also backfilled a missing Sprint 52 summary-table row); Store status -> LIVE 0.5.9.0
- mobile-app/pubspec.yaml: dev version bumped 0.5.9 -> 0.5.10 (top-level `version:` only; `msix_version` deliberately left at 0.5.9.0 until the next release build)
- .claude/sprint_status.json: rolled sprint state, recorded the Sprint 53 retrospective skip (explicit Product Owner decision, Harold 2026-08-03)

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/policy/version_consistency_test.dart` green after the version bump
- [x] Partner Center confirms Submission 10 live (Store-presence section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)